### PR TITLE
Nginxns primitive

### DIFF
--- a/nginxns.py
+++ b/nginxns.py
@@ -579,8 +579,7 @@ def read(
         retval = False
         message_list.append(messages[3217])
     else:
-        retval = False
-        message_list.append(messages[3218])
+        return retval, data_dict, message_list
 
     # define payloads
     read_config_payload = f'cat {nginx_config_path}'

--- a/nginxns.py
+++ b/nginxns.py
@@ -711,7 +711,7 @@ def read(
         retval = False
         message_list.append(messages[3234]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
 
-    data_dict[enabled]['process_status'] = stdout
+    data_dict[disabled]['process_status'] = stdout
 
     message_list.append(messages[1200])
     return retval, data_dict, message_list

--- a/nginxns.py
+++ b/nginxns.py
@@ -580,6 +580,8 @@ def read(
         message_list.append(messages[3217])
     else:
         message_list.append(messages[3218])
+
+    if retval == False:
         return retval, data_dict, message_list
 
     # define payloads

--- a/nginxns.py
+++ b/nginxns.py
@@ -50,7 +50,7 @@ def build(
     """
 
     nginx_config_path = '/etc/netns/{namespace}/nginx.conf'
-    pidfile= '/run/nginx-{namespace}s.pid'
+    pidfile= '/etc/netns/{namespace}/nginx.pid'
 
     # Define message
     messages = {
@@ -484,7 +484,7 @@ def read(
     """
 
     nginx_config_path = '/etc/netns/{namespace}/nginx.conf'
-    pidfile= '/run/nginx-{namespace}s.pid'
+    pidfile = '/etc/netns/{namespace}/nginx.conf'
 
     # Define message
     messages = {

--- a/nginxns.py
+++ b/nginxns.py
@@ -541,7 +541,7 @@ def read(
     messages = {
         1200: f'1200: Successfully retrieved nginx process status and {nginx_config_path}s from both PodNet nodes.',
         2211: f'2211: Config file {config_file} loaded.',
-        3211: f'3211: Failed to load config file {config_file}, It does not exist.',
+        3211: f'3211: Failed to load config file {config_file}: ',
         3212: f'3212: Failed to get `ipv6_subnet` from config file {config_file}',
         3213: f'3213: Invalid value for `ipv6_subnet` from config file {config_file}',
         3214: f'3214: Failed to get `podnet_a_enabled` from config file {config_file}',
@@ -572,11 +572,13 @@ def read(
         config_file = '/opt/robot/config.json'
 
     # Get load config from config_file
-    if not Path(config_file).exists():
+    try:
+      with Path(config_file).open('r') as file:
+          config = json.load(file)
+    except Exception as e:
         retval = False
-        message_list.append(messages[3211])
-    with Path(config_file).open('r') as file:
-        config = json.load(file)
+        message_list.append(messages[3211] + e.__str__())
+        return retval, data_dict, message_list
 
     # Get the ipv6_subnet from config_file
     ipv6_subnet = config.get('ipv6_subnet', None)

--- a/nginxns.py
+++ b/nginxns.py
@@ -1,0 +1,635 @@
+"""
+Primitive to Build, Read and Scrub nginx for cloud-init userdata/metadata delivery on PodNet HA
+"""
+
+# stdlib
+import json
+import ipaddress
+from pathlib import Path
+from typing import Tuple
+# lib
+from cloudcix.rcc import comms_ssh, CouldNotConnectException
+# local
+
+
+__all__ = [
+    'build',
+    'read',
+    'scrub',
+]
+
+SUCCESS_CODE = 0
+
+
+def build(
+        domain_path: str,
+        domain: str,
+        interfaces: dict,
+        config_file=None,
+        userdata=""
+) -> Tuple[bool, str]:
+    """
+    description:
+        Creates cloud-init user data and meta data files for a virtual machine on PodNet HA.
+
+    parameters:
+        domain_path:
+            description: | path to the virtual machine's cloud-init directory.
+                           This must be the full path, up to and including the
+                           metaddata version component.
+            type: string
+            required: true
+        metadata:
+          description: data structure that contains the machine's metadata
+          type: object
+          required: true
+          properties:
+            instance_id:
+              type: string
+              required: true
+              description: | libvirt domain name for VM. Typically composed from
+                             numerical project ID and VM ID as follows:
+                             `<project_id>_<domain_id>`.
+            network:
+              type: object
+              required: true
+              description: the VM's network configuration
+              properties:
+                nameservers:
+                  description: the VM's DNS configuration
+                  type: object
+                  required: true
+                  properties:
+                    addresses:
+                      description: list of name server IP addresses
+                      type: array
+                      required: true
+                      items:
+                        description: a name server IP address such as `8.8.8.8`. At least one must be specified.
+                        type: string
+                        required: true
+                    search:
+                      type: array
+                      description: the machine's search domains for unqualified host names
+                      required: false
+                      items:
+                        description: | a search domain to qualify unqualified
+                                       host names with, such as `cloudcix.com`
+                        required: false
+                        type: string
+                interfaces:
+                  type: object
+                  required: true
+                  description: The VM's network interface configuration
+                  properties:
+                    mac_address:
+                      description: | The interface's MAC address (colon separated
+                                     bytes, lower case)
+                      type: string
+                      required: true
+                    addresses:
+                      description: The interface's IP addresses. At least one is required.
+                      type: array
+                      required: true
+                      items:
+                        description: | an IP address with subnet mask specified
+                                       in CIDR notation as understood by ip(8), e.g.
+                                       `10.0.5.221/24`
+                        type: string
+                        required: true
+                    routes:
+                      description: routes to create for this particular interface. While optional, setting at
+                                   least a default route is highly recommended.
+                      type: object
+                      required: false
+                      properties:
+                        to:
+                          description: | the route's destination. either a network
+                                         address with subnet mask specified in
+                                         CIDR notation, e.g. `10.0.6.0/8` or the
+                                         keyword `default` to indicate a default
+                                         route.
+                          type: string
+                          required: true
+                        via:
+                          description: | IP address of the route's next hop, e.g.
+                                         `10.0.0.1`.
+                          type: string
+                          required: true
+        config_file:
+            description: path to the config.json file
+            type: string
+            required: false
+        userdata:
+            description: the cloud-init user data payload to pass into the virtual machine
+            type: string
+            required: true
+    return:
+        description: |
+            A tuple with a boolean flag stating if the build was successful or not and
+            the output or error message.
+        type: tuple
+    """
+    # Define message
+    messages = {
+        1000: f'1000: Successfully created {domain_path}/metadata and {domain_path}/userdata on both PodNet nodes.',
+        2111: f'2011: Config file {config_file} loaded.',
+        3011: f'3011: Failed to load config file {config_file}, It does not exist.',
+        3012: f'3012: Failed to get `ipv6_subnet` from config file {config_file}',
+        3013: f'3013: Invalid value for `ipv6_subnet` from config file {config_file}',
+        3014: f'3014: Failed to get `podnet_a_enabled` from config file {config_file}',
+        3015: f'3015: Failed to get `podnet_b_enabled` from config file {config_file}',
+        3016: f'3016: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
+        3017: f'3017: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
+        3018: f'3018: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
+        3021: f'3021: Failed to connect to the enabled PodNet from the config file {config_file} for create_metadata payload',
+        3022: f'3022: Failed to create metadata file {domain_path}/metadata on the enabled PodNet. Payload exited with status ',
+        3023: f'3023: Failed to connect to the enabled PodNet from the config file {config_file} for create_userdata payload',
+        3023: f'3024: Failed to create userdata file {domain_path}/userdata on the enabled PodNet Payload exited with status ',
+        3031: f'3031: Successfully created `metadata` and `userdata` in {domain_path}/ on enabled PodNet but failed to connect to the disabled PodNet '
+              f'from the config file {config_file}',
+        3032: f'3032: Successfully created `metadata` and `userdata` in {domain_path}/ on enabled PodNet but failed to create on the disabled PodNet. '
+               'Payload exited with status ',
+        3033: f'3033: Successfully created `metadata` and `userdata` in {domain_path}/ on enabled PodNet but failed to connect to the disabled PodNet. '
+              f'from the config file {config_file}',
+        3034: f'3034: Successfully created `metadata` and `userdata` in {domain_path}/ on enabled PodNet but failed to create on the disabled PodNet. '
+               'Payload exited with status ',
+    }
+
+    metadata_json = json.dumps(
+        metadata,
+        indent=1,
+        sort_keys=True,
+    )
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/etc/cloudcix/pod/configs/config.json'
+
+    # Get load config from config_file
+    if not Path(config_file).exists():
+        return False, messages[3011]
+    with Path(config_file).open('r') as file:
+        config = json.load(file)
+
+    # Get the ipv6_subnet from config_file
+    ipv6_subnet = config.get('ipv6_subnet', None)
+    if ipv6_subnet is None:
+        return False, messages[3012]
+    # Verify the ipv6_subnet value
+    try:
+        ipaddress.ip_network(ipv6_subnet)
+    except ValueError:
+        return False, messages[3013]
+
+    # Get the PodNet Mgmt ips from ipv6_subnet
+    podnet_a = f'{ipv6_subnet.split("/")[0]}10:0:2'
+    podnet_b = f'{ipv6_subnet.split("/")[0]}10:0:3'
+
+    # Get `podnet_a_enabled` and `podnet_b_enabled`
+    podnet_a_enabled = config.get('podnet_a_enabled', None)
+    if podnet_a_enabled is None:
+        return False, messages[3014]
+    podnet_b_enabled = config.get('podnet_b_enabled', None)
+    if podnet_a_enabled is None:
+        return False, messages[3015]
+
+    # First run on enabled PodNet
+    if podnet_a_enabled is True and podnet_b_enabled is False:
+        enabled = podnet_a
+        disabled = podnet_b
+    elif podnet_a_enabled is False and podnet_b_enabled is True:
+        enabled = podnet_b
+        disabled = podnet_a
+    elif podnet_a_enabled is True and podnet_b_enabled is True:
+        return False, messages[3016]
+    elif podnet_a_enabled is False and podnet_b_enabled is False:
+        return False, messages[3017]
+    else:
+        return False, messages[3018]
+
+    # define payloads
+    create_userdata_payload = "\n".join([
+        f'tee {domain_path} userdata <<EOF',
+        userdata,
+        "EOF"
+        ])
+
+    create_metadata_payload = "\n".join([
+        f'tee {domain_path} metadata <<EOF',
+        metadata_json,
+        "EOF"
+        ])
+
+    # call rcc comms_ssh on enabled PodNet
+    try:
+        create_metadata, stdout, stderr = comms_ssh(
+            host_ip=enabled,
+            payload=create_metadata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3021]
+
+    if create_metadata.exit_code != SUCCESS_CODE:
+        return False, messages[3022] + f'{create_metadata.exit_code}s.'
+
+    # call rcc comms_ssh on enabled PodNet
+    try:
+        create_userdata, stdout, stderr = comms_ssh(
+            host_ip=enabled,
+            payload=create_userdata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3023]
+
+    if create_userdata.exit_code != SUCCESS_CODE:
+        return False, messages[3024]  + f'{create_userdata.exit_code}s.'
+
+    # call rcc comms_ssh on disabled PodNet
+    try:
+        create_metadata, stdout, stderr = comms_ssh(
+            host_ip=disabled,
+            payload=create_metadata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3031]
+
+    if create_metadata.exit_code != SUCCESS_CODE:
+        return False, messages[3032] + f'{create_metadata.exit_code}s.'
+
+    # call rcc comms_ssh on disabled PodNet
+    try:
+        create_userdata, stdout, stderr = comms_ssh(
+            host_ip=disabled,
+            payload=create_userdata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3033]
+
+    if create_userdata.exit_code != SUCCESS_CODE:
+        return False, messages[3034]  + f'{create_userdata.exit_code}s.'
+
+
+    return True, messages[1000]
+
+
+def scrub(
+        domain_path: str,
+) -> Tuple[bool, str]:
+    """
+    description:
+        Removes cloud-init user data and meta data files for a virtual machine on PodNet HA.
+
+    parameters:
+        domain_path:
+            description: path to the virtual machine's cloud-init directory.
+                         This must be the full path, up to and including the
+                         version component.
+            type: string
+            required: true
+        config_file:
+            description: path to the config.json file
+            type: string
+            required: false
+    return:
+        description: |
+            A tuple with a boolean flag stating if the scrub was successful or not and
+            the output or error message.
+        type: tuple
+    """
+    # Define message
+    messages = {
+        1100: f'1100: Successfully removed {domain_path}/, {domain_path}/metadata and {domain_path}/userdata on both PodNet nodes.',
+        2111: f'2111: Config file {config_file} loaded.',
+        3111: f'3111: Failed to load config file {config_file}, It does not exist.',
+        3112: f'3112: Failed to get `ipv6_subnet` from config file {config_file}',
+        3113: f'3113: Invalid value for `ipv6_subnet` from config file {config_file}',
+        3114: f'3114: Failed to get `podnet_a_enabled` from config file {config_file}',
+        3115: f'3115: Failed to get `podnet_b_enabled` from config file {config_file}',
+        3116: f'3116: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
+        3117: f'3117: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
+        3118: f'3118: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
+        3121: f'3121: Failed to connect to the enabled PodNet from the config file {config_file} for remove_metadata payload',
+        3122: f'3122: Failed to create metadata file {domain_path}/metadata on the enabled PodNet. Payload exited with status ',
+        3123: f'3123: Failed to connect to the enabled PodNet from the config file {config_file} for remove_userdata payload',
+        3123: f'3124: Failed to create userdata file {domain_path}/userdata on the enabled PodNet Payload exited with status ',
+        3131: f'3131: Successfully removed `metadata` and `userdata` in {domain_path}/ on enabled PodNet but failed to connect to the disabled PodNet '
+              f'from the config file {config_file}',
+        3132: f'3132: Successfully removed `metadata` and `userdata` in {domain_path}/ on enabled PodNet but failed to create on the disabled PodNet. '
+               'Payload exited with status ',
+        3133: f'3133: Successfully removed `metadata` and `userdata` in {domain_path}/ on enabled PodNet but failed to connect to the disabled PodNet. '
+              f'from the config file {config_file}',
+        3134: f'3134: Successfully removed `metadata` and `userdata` in {domain_path}/ on enabled PodNet but failed to create on the disabled PodNet. '
+               'Payload exited with status ',
+    }
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/etc/cloudcix/pod/configs/config.json'
+
+    # Get load config from config_file
+    if not Path(config_file).exists():
+        return False, messages[3111]
+    with Path(config_file).open('r') as file:
+        config = json.load(file)
+
+    # Get the ipv6_subnet from config_file
+    ipv6_subnet = config.get('ipv6_subnet', None)
+    if ipv6_subnet is None:
+        return False, messages[3112]
+    # Verify the ipv6_subnet value
+    try:
+        ipaddress.ip_network(ipv6_subnet)
+    except ValueError:
+        return False, messages[3113]
+
+    # Get the PodNet Mgmt ips from ipv6_subnet
+    podnet_a = f'{ipv6_subnet.split("/")[0]}10:0:2'
+    podnet_b = f'{ipv6_subnet.split("/")[0]}10:0:3'
+
+    # Get `podnet_a_enabled` and `podnet_b_enabled`
+    podnet_a_enabled = config.get('podnet_a_enabled', None)
+    if podnet_a_enabled is None:
+        return False, messages[3114]
+    podnet_b_enabled = config.get('podnet_b_enabled', None)
+    if podnet_a_enabled is None:
+        return False, messages[3115]
+
+    # First run on enabled PodNet
+    if podnet_a_enabled is True and podnet_b_enabled is False:
+        enabled = podnet_a
+        disabled = podnet_b
+    elif podnet_a_enabled is False and podnet_b_enabled is True:
+        enabled = podnet_b
+        disabled = podnet_a
+    elif podnet_a_enabled is True and podnet_b_enabled is True:
+        return False, messages[3116]
+    elif podnet_a_enabled is False and podnet_b_enabled is False:
+        return False, messages[3117]
+    else:
+        return False, messages[3118]
+
+    # define payloads
+    remove_userdata_payload = f'rm -f {domain_path}/userdata'
+    remove_metadata_payload = f'rm -f {domain_path}/metadata'
+
+    # call rcc comms_ssh for metadata removal on enabled PodNet
+    try:
+        remove_metadata, stdout, stderr = comms_ssh(
+            host_ip=enabled,
+            payload=remove_metadata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3121]
+
+    if remove_metadata.exit_code != SUCCESS_CODE:
+        return False, messages[3122] + f'{remove_metadata.exit_code}s.'
+
+    # call rcc comms_ssh for userdata removal on enabled PodNet
+    try:
+        remove_userdata, stdout, stderr = comms_ssh(
+            host_ip=enabled,
+            payload=remove_userdata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3123]
+
+    if remove_userdata.exit_code != SUCCESS_CODE:
+        return False, messages[3124]  + f'{remove_userdata.exit_code}s.'
+
+    # call rcc comms_ssh for metadata removal on disabled PodNet
+    try:
+        remove_metadata, stdout, stderr = comms_ssh(
+            host_ip=disabled,
+            payload=remove_metadata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3131]
+
+    if remove_metadata.exit_code != SUCCESS_CODE:
+        return False, messages[3132] + f'{remove_metadata.exit_code}s.'
+
+    # call rcc comms_ssh for userdata removal on disabled PodNet
+    try:
+        remove_userdata, stdout, stderr = comms_ssh(
+            host_ip=disabled,
+            payload=remove_userdata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3133]
+
+    if remove_userdata.exit_code != SUCCESS_CODE:
+        return False, messages[3134]  + f'{remove_userdata.exit_code}s.'
+
+
+    return True, messages[1100]
+
+def read(
+        domain_path: str,
+) -> Tuple[bool, dict, str]:
+    """
+    description:
+        Reads cloud-init user data and meta data files for a virtual machine on
+        PodNet HA (if any) and returns them.
+
+    parameters:
+        domain_path:
+            description: path to the virtual machine's cloud-init directory.
+                         This must be the full path, up to and including the
+                         version component.
+            type: string
+            required: true
+        config_file:
+            description: path to the config.json file
+            type: string
+            required: false
+    return:
+        description: |
+            A list with 3 items: (1) a boolean status flag indicating if the
+            read was successfull, (2) a dict containing the data as read from
+            the both machines' current state and (3) the output or success message.
+        type: tuple
+        items:
+          read:
+            description: True if all read operations were successful, False otherwise.
+            type: boolean
+          data:
+            type: object
+            description: |
+              file contents retrieved from both podnet nodes. May be None if nothing
+              could be retrieved.
+            properties:
+              <podnet_ip>:
+                description: dict structure holding user data from machine <podnet_ip>
+                  type: object
+                  userdata:
+                    description: |
+                      The contents of the `userdata` file at domain_path. May be
+                      None upon any read errors.
+                    type: string
+                  metadata:
+                    type: string
+                    description: |
+                      The contents of the `metadata` file at domain_path. May be
+                      None upon any read errors.
+    """
+
+    # Define message
+    messages = {
+        1200: f'1200: Successfully retrieved {domain_path}/, {domain_path}/metadata and {domain_path}/userdata from both PodNet nodes.',
+        2211: f'2211: Config file {config_file} loaded.',
+        3211: f'3211: Failed to load config file {config_file}, It does not exist.',
+        3212: f'3212: Failed to get `ipv6_subnet` from config file {config_file}',
+        3213: f'3213: Invalid value for `ipv6_subnet` from config file {config_file}',
+        3214: f'3214: Failed to get `podnet_a_enabled` from config file {config_file}',
+        3215: f'3215: Failed to get `podnet_b_enabled` from config file {config_file}',
+        3216: f'3216: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
+        3217: f'3217: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
+        3218: f'3218: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
+        3221: f'3221: Failed to connect to the enabled PodNet from the config file {config_file} for read_metadata payload',
+        3222: f'3222: Failed to read metadata file {domain_path}/metadata on the enabled PodNet. Payload exited with status ',
+        3223: f'3223: Failed to connect to the enabled PodNet from the config file {config_file} for read_userdata payload',
+        3223: f'3224: Failed to read userdata file {domain_path}/userdata on the enabled PodNet Payload exited with status ',
+        3231: f'3231: Successfully read `metadata` and `userdata` from {domain_path}/ on enabled PodNet but failed to connect to the disabled PodNet '
+              f'from the config file {config_file}',
+        3232: f'3232: Successfully read `metadata` and `userdata` from {domain_path}/ on enabled PodNet but failed to read on the disabled PodNet. '
+               'Payload exited with status ',
+        3233: f'3233: Successfully read `metadata` and `userdata` from {domain_path}/ on enabled PodNet but failed to connect to the disabled PodNet. '
+              f'from the config file {config_file}',
+        3234: f'3234: Successfully read `metadata` and `userdata` from {domain_path}/ on enabled PodNet but failed to read on the disabled PodNet. '
+               'Payload exited with status ',
+    }
+
+    data_dict = None
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/etc/cloudcix/pod/configs/config.json'
+
+    # Get load config from config_file
+    if not Path(config_file).exists():
+        return False, data_dict, messages[3211]
+    with Path(config_file).open('r') as file:
+        config = json.load(file)
+
+    # Get the ipv6_subnet from config_file
+    ipv6_subnet = config.get('ipv6_subnet', None)
+    if ipv6_subnet is None:
+        return False, data_dict, messages[3212]
+    # Verify the ipv6_subnet value
+    try:
+        ipaddress.ip_network(ipv6_subnet)
+    except ValueError:
+        return False, data_dict, messages[3213]
+
+    # Get the PodNet Mgmt ips from ipv6_subnet
+    podnet_a = f'{ipv6_subnet.split("/")[0]}10:0:2'
+    podnet_b = f'{ipv6_subnet.split("/")[0]}10:0:3'
+
+    data_dict = {}
+
+    data_dict[podnet_a] = {
+        'userdata': None,
+        'metadata': None,
+    }
+
+    data_dict[podnet_b] = {
+        'userdata': None,
+        'metadata': None,
+    }
+
+    # Get `podnet_a_enabled` and `podnet_b_enabled`
+    podnet_a_enabled = config.get('podnet_a_enabled', None)
+    if podnet_a_enabled is None:
+        return False, data_dict, messages[3214]
+    podnet_b_enabled = config.get('podnet_b_enabled', None)
+    if podnet_a_enabled is None:
+        return False, data_dict, messages[3215]
+
+    # First run on enabled PodNet
+    if podnet_a_enabled is True and podnet_b_enabled is False:
+        enabled = podnet_a
+        disabled = podnet_b
+    elif podnet_a_enabled is False and podnet_b_enabled is True:
+        enabled = podnet_b
+        disabled = podnet_a
+    elif podnet_a_enabled is True and podnet_b_enabled is True:
+        return False, data_dict, messages[3216]
+    elif podnet_a_enabled is False and podnet_b_enabled is False:
+        return False, data_dict, messages[3217]
+    else:
+        return False, data_dict, messages[3218]
+
+    # define payloads
+    read_userdata_payload = f'cat {domain_path}/userdata'
+    read_metadata_payload = f'cat {domain_path}/metadata'
+
+    # call rcc comms_ssh for metadata retrieval from enabled PodNet
+    try:
+        read_metadata, stdout, stderr = comms_ssh(
+            host_ip=enabled,
+            payload=read_metadata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, data_dict, messages[3221]
+
+    if read_metadata.exit_code != SUCCESS_CODE:
+        return False, data_dict, messages[3222] + f'{read_metadata.exit_code}s.'
+
+    data_dict[enabled]['metadata'] = stdout
+
+    # call rcc comms_ssh for userdata retrieval from enabled PodNet
+    try:
+        read_userdata, stdout, stderr = comms_ssh(
+            host_ip=enabled,
+            payload=read_userdata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, data_dict, messages[3223]
+
+    if read_userdata.exit_code != SUCCESS_CODE:
+        return False, data_dict, messages[3224]  + f'{read_userdata.exit_code}s.'
+
+    data_dict[enabled]['userdata'] = stdout
+
+    # call rcc comms_ssh for metadata retrieval from disabled PodNet
+    try:
+        read_metadata, stdout, stderr = comms_ssh(
+            host_ip=disabled,
+            payload=read_metadata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, data_dict, messages[3231]
+
+    if read_metadata.exit_code != SUCCESS_CODE:
+        return False, data_dict, messages[3232] + f'{read_metadata.exit_code}s.'
+
+    data_dict[enabled]['metadata'] = stdout
+
+    # call rcc comms_ssh for userdata retrieval from disabled PodNet
+    try:
+        read_userdata, stdout, stderr = comms_ssh(
+            host_ip=disabled,
+            payload=read_userdata_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, data_dict, messages[3233]
+
+    if read_userdata.exit_code != SUCCESS_CODE:
+        return False, data_dict, messages[3234]  + f'{read_userdata.exit_code}s.'
+
+    data_dict[enabled]['userdata'] = stdout
+
+    return True, data_dict, messages[1200]

--- a/nginxns.py
+++ b/nginxns.py
@@ -39,7 +39,9 @@ def build(
             type: string
             required: true
         config_file:
-            description: path to the config.json file
+            description: |
+                path to the config.json file. Defaults to /opt/robot/config.json
+                if unspecified.
             type: string
             required: false
     return:
@@ -89,7 +91,7 @@ def build(
 
     # Default config_file if it is None
     if config_file is None:
-        config_file = '/etc/cloudcix/pod/configs/config.json'
+        config_file = '/opt/robot/config.json'
 
     # Get load config from config_file
     if not Path(config_file).exists():
@@ -287,7 +289,9 @@ def scrub(
             type: string
             required: true
         config_file:
-            description: path to the config.json file
+            description: |
+                path to the config.json file. Defaults to /opt/robot/config.json
+                if unspecified.
             type: string
             required: false
     return:
@@ -335,7 +339,7 @@ def scrub(
 
     # Default config_file if it is None
     if config_file is None:
-        config_file = '/etc/cloudcix/pod/configs/config.json'
+        config_file = '/opt/robot/config.json'
 
     # Get load config from config_file
     if not Path(config_file).exists():
@@ -489,7 +493,9 @@ def read(
             type: string
             required: true
         config_file:
-            description: path to the config.json file
+            description: |
+                path to the config.json file. Defaults to /opt/robot/config.json
+                if unspecified.
             type: string
             required: false
     return:
@@ -519,7 +525,7 @@ def read(
                   config_file:
                     type: string
                     description: |
-                      The contents of the `metadata` file at domain_path. May be
+                      The contents of the nginx configuration file. May be
                       None upon any read errors.
           errors:
             type: array
@@ -563,7 +569,7 @@ def read(
 
     # Default config_file if it is None
     if config_file is None:
-        config_file = '/etc/cloudcix/pod/configs/config.json'
+        config_file = '/opt/robot/config.json'
 
     # Get load config from config_file
     if not Path(config_file).exists():

--- a/nginxns.py
+++ b/nginxns.py
@@ -654,4 +654,5 @@ def read(
 
     data_dict[enabled]['process_status'] = stdout
 
-    return retval, data_dict, messages[1200]
+    message_list.append(messages[1200])
+    return retval, data_dict, message_list

--- a/nginxns.py
+++ b/nginxns.py
@@ -170,7 +170,7 @@ def build(
     if (exit_code == SUCCESS_CODE) and (stdout != ""):
         reload_nginx_payload = f'kill -HUP {stdout}s'
     else:
-       return False, messages[3021] + f'{exit_code}s.'
+       return False, messages[3021] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     # call rcc comms_ssh on enabled PodNet to create config
     try:
@@ -183,7 +183,7 @@ def build(
         return False, messages[3022]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3023] + f'{exit_code}s.'
+        return False, messages[3023] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     if reload_nginx_payload is not None:
         # call rcc comms_ssh on enabled PodNet to SIGHUP existing process
@@ -197,7 +197,7 @@ def build(
             return False, messages[3024]
 
         if exit_code != SUCCESS_CODE:
-            return False, messages[3025]  + f'{exit_code}s.'
+            return False, messages[3025]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
     else:
         # call rcc comms_ssh on enabled PodNet
         try:
@@ -210,7 +210,7 @@ def build(
             return False, messages[3026]
 
         if exit_code != SUCCESS_CODE:
-            return False, messages[3027]  + f'{exit_code}s.'
+            return False, messages[3027]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
 
     # call rcc comms_ssh on disabled PodNet to find existing process
@@ -227,7 +227,7 @@ def build(
     if (exit_code == SUCCESS_CODE) and (stdout != ""):
         reload_nginx_payload_enabled = f'kill -HUP {stdout}s'
     else:
-       return False, messages[3031] + f'{exit_code}s.'
+       return False, messages[3031] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     # call rcc comms_ssh on disabled PodNet
     try:
@@ -240,7 +240,7 @@ def build(
         return False, messages[3032]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3033] + f'{exit_code}s.'
+        return False, messages[3033] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     if reload_nginx_payload_disabled is None:
         # call rcc comms_ssh on disabled PodNet to SIGHUP existing process
@@ -254,7 +254,7 @@ def build(
             return False, messages[3034]
 
         if exit_code != SUCCESS_CODE:
-            return False, messages[3035]  + f'{exit_code}s.'
+            return False, messages[3035]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
     else:
         # call rcc comms_ssh on disabled PodNet
         try:
@@ -267,7 +267,7 @@ def build(
             return False, messages[3036]
 
         if exit_code != SUCCESS_CODE:
-            return False, messages[3037]  + f'{exit_code}s.'
+            return False, messages[3037]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
 
     return True, messages[1000]
@@ -394,13 +394,13 @@ def scrub(
         return False, messages[3119]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3120] + f'{exit_code}s.'
+        return False, messages[3120] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     stop_nginx_payload = None
     if (exit_code == SUCCESS_CODE) and (stdout != ""):
         stop_nginx_payload = f'kill {stdout}s'
     else:
-        return False, messages[3121] + f'{exit_code}s.'
+        return False, messages[3121] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     if stop_nginx_payload is not None:
         # call rcc comms_ssh on enabled PodNet to kill existing process
@@ -413,7 +413,7 @@ def scrub(
         except CouldNotConnectException:
             return False, messages[3122]
         if exit_code != SUCCESS_CODE:
-            return False, messages[3123]  + f'{exit_code}s.'
+            return False, messages[3123]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     # call rcc comms_ssh for nginx config file removal on enabled PodNet
     try:
@@ -426,7 +426,7 @@ def scrub(
         return False, messages[3124]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3125]  + f'{exit_code}s.'
+        return False, messages[3125]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     # call rcc comms_ssh on disabled PodNet to find existing process
     try:
@@ -439,13 +439,13 @@ def scrub(
         return False, messages[3129]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3130] + f'{exit_code}s.'
+        return False, messages[3130] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     stop_nginx_payload = None
     if (exit_code == SUCCESS_CODE) and (stdout != ""):
         stop_nginx_payload = f'kill {stdout}s'
     else:
-        return False, messages[3131] + f'{exit_code}s.'
+        return False, messages[3131] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     if stop_nginx_payload is not None:
         # call rcc comms_ssh on disabled PodNet to kill existing process
@@ -458,7 +458,7 @@ def scrub(
         except CouldNotConnectException:
             return False, messages[3132]
         if exit_code != SUCCESS_CODE:
-            return False, messages[3133]  + f'{exit_code}s.'
+            return False, messages[3133]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     # call rcc comms_ssh for nginx config file removal on disabled PodNet
     try:
@@ -471,7 +471,7 @@ def scrub(
         return False, messages[3134]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3135]  + f'{exit_code}s.'
+        return False, messages[3135]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     return True, messages[1100]
 
@@ -647,7 +647,7 @@ def read(
 
     if ( exit_code is not None ) and ( exit_code != SUCCESS_CODE ):
         retval = False
-        message_list.append(messages[3222] + f'{exit_code}s.')
+        message_list.append(messages[3222] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
 
     data_dict[enabled]['config_file'] = stdout
 
@@ -665,7 +665,7 @@ def read(
 
     if ( exit_code is not None ) and ( exit_code != SUCCESS_CODE ):
         retval = False
-        message_list.append(messages[3224]  + f'{exit_code}s.')
+        message_list.append(messages[3224]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
 
     data_dict[enabled]['process_status'] = stdout
 
@@ -683,7 +683,7 @@ def read(
 
     if ( exit_code is not None ) and ( exit_code != SUCCESS_CODE ):
         retval = False
-        message_list.append(messages[3232] + f'{exit_code}s.')
+        message_list.append(messages[3232] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
 
     data_dict[enabled]['config_file'] = stdout
 
@@ -701,7 +701,7 @@ def read(
 
     if ( exit_code is not None ) and ( exit_code != SUCCESS_CODE ):
         retval = False
-        message_list.append(messages[3234]  + f'{exit_code}s.')
+        message_list.append(messages[3234]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
 
     data_dict[enabled]['process_status'] = stdout
 

--- a/nginxns.py
+++ b/nginxns.py
@@ -158,7 +158,7 @@ def build(
 
     # call rcc comms_ssh on enabled PodNet to find existing process
     try:
-        existing_process, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=enabled,
             payload=find_process_payload,
             username='robot',
@@ -167,14 +167,14 @@ def build(
         return False, messages[3020]
 
     reload_nginx_payload = None
-    if (existing_process.exit_code == SUCCESS_CODE) and (stdout != ""):
+    if (exit_code == SUCCESS_CODE) and (stdout != ""):
         reload_nginx_payload = f'kill -HUP {stdout}s'
     else:
-       return False, messages[3021] + f'{existing_process.exit_code}s.'
+       return False, messages[3021] + f'{exit_code}s.'
 
     # call rcc comms_ssh on enabled PodNet to create config
     try:
-        create_config, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=enabled,
             payload=create_config_payload,
             username='robot',
@@ -182,13 +182,13 @@ def build(
     except CouldNotConnectException:
         return False, messages[3022]
 
-    if create_config.exit_code != SUCCESS_CODE:
-        return False, messages[3023] + f'{create_config.exit_code}s.'
+    if exit_code != SUCCESS_CODE:
+        return False, messages[3023] + f'{exit_code}s.'
 
     if reload_nginx_payload is not None:
         # call rcc comms_ssh on enabled PodNet to SIGHUP existing process
         try:
-            start_nginx, stdout, stderr = comms_ssh(
+            exit_code, stdout, stderr = comms_ssh(
                 host_ip=enabled,
                 payload=reload_nginx_payload,
                 username='robot',
@@ -196,12 +196,12 @@ def build(
         except CouldNotConnectException:
             return False, messages[3024]
 
-        if start_nginx.exit_code != SUCCESS_CODE:
-            return False, messages[3025]  + f'{start_nginx.exit_code}s.'
+        if exit_code != SUCCESS_CODE:
+            return False, messages[3025]  + f'{exit_code}s.'
     else:
         # call rcc comms_ssh on enabled PodNet
         try:
-            start_nginx, stdout, stderr = comms_ssh(
+            exit_code, stdout, stderr = comms_ssh(
                 host_ip=enabled,
                 payload=start_nginx_payload,
                 username='robot',
@@ -209,13 +209,13 @@ def build(
         except CouldNotConnectException:
             return False, messages[3026]
 
-        if start_nginx.exit_code != SUCCESS_CODE:
-            return False, messages[3027]  + f'{start_nginx.exit_code}s.'
+        if exit_code != SUCCESS_CODE:
+            return False, messages[3027]  + f'{exit_code}s.'
 
 
     # call rcc comms_ssh on disabled PodNet to find existing process
     try:
-        existing_process, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=enabled,
             payload=find_process_payload,
             username='robot',
@@ -224,14 +224,14 @@ def build(
         return False, messages[3030]
 
     reload_nginx_payload_disabled = None
-    if (existing_process.exit_code == SUCCESS_CODE) and (stdout != ""):
+    if (exit_code == SUCCESS_CODE) and (stdout != ""):
         reload_nginx_payload_enabled = f'kill -HUP {stdout}s'
     else:
-       return False, messages[3031] + f'{existing_process.exit_code}s.'
+       return False, messages[3031] + f'{exit_code}s.'
 
     # call rcc comms_ssh on disabled PodNet
     try:
-        create_config, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=disabled,
             payload=create_config_payload,
             username='robot',
@@ -239,13 +239,13 @@ def build(
     except CouldNotConnectException:
         return False, messages[3032]
 
-    if create_config.exit_code != SUCCESS_CODE:
-        return False, messages[3033] + f'{create_config.exit_code}s.'
+    if exit_code != SUCCESS_CODE:
+        return False, messages[3033] + f'{exit_code}s.'
 
     if reload_nginx_payload_disabled is None:
         # call rcc comms_ssh on disabled PodNet to SIGHUP existing process
         try:
-            start_nginx, stdout, stderr = comms_ssh(
+            exit_code, stdout, stderr = comms_ssh(
                 host_ip=disabled,
                 payload=reload_nginx_payload,
                 username='robot',
@@ -253,12 +253,12 @@ def build(
         except CouldNotConnectException:
             return False, messages[3034]
 
-        if start_nginx.exit_code != SUCCESS_CODE:
-            return False, messages[3035]  + f'{start_nginx.exit_code}s.'
+        if exit_code != SUCCESS_CODE:
+            return False, messages[3035]  + f'{exit_code}s.'
     else:
         # call rcc comms_ssh on disabled PodNet
         try:
-            start_nginx, stdout, stderr = comms_ssh(
+            exit_code, stdout, stderr = comms_ssh(
                 host_ip=disabled,
                 payload=start_nginx_payload,
                 username='robot',
@@ -266,8 +266,8 @@ def build(
         except CouldNotConnectException:
             return False, messages[3036]
 
-        if start_nginx.exit_code != SUCCESS_CODE:
-            return False, messages[3037]  + f'{start_nginx.exit_code}s.'
+        if exit_code != SUCCESS_CODE:
+            return False, messages[3037]  + f'{exit_code}s.'
 
 
     return True, messages[1000]
@@ -377,7 +377,7 @@ def scrub(
 
     # call rcc comms_ssh for stopping nginx on enabled PodNet
     try:
-        stop_nginx, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=enabled,
             payload=stop_nginx_payload,
             username='robot',
@@ -385,12 +385,12 @@ def scrub(
     except CouldNotConnectException:
         return False, messages[3121]
 
-    if stop_nginx.exit_code != SUCCESS_CODE:
-        return False, messages[3122] + f'{stop_nginx.exit_code}s.'
+    if exit_code != SUCCESS_CODE:
+        return False, messages[3122] + f'{exit_code}s.'
 
     # call rcc comms_ssh for nginx config file removal on enabled PodNet
     try:
-        remove_config, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=enabled,
             payload=remove_config_payload,
             username='robot',
@@ -398,12 +398,12 @@ def scrub(
     except CouldNotConnectException:
         return False, messages[3123]
 
-    if remove_config.exit_code != SUCCESS_CODE:
-        return False, messages[3124]  + f'{remove_config.exit_code}s.'
+    if exit_code != SUCCESS_CODE:
+        return False, messages[3124]  + f'{exit_code}s.'
 
     # call rcc comms_ssh for stopping nginx on disabled PodNet
     try:
-        stop_nginx, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=disabled,
             payload=stop_nginx_payload,
             username='robot',
@@ -411,12 +411,12 @@ def scrub(
     except CouldNotConnectException:
         return False, messages[3131]
 
-    if stop_nginx.exit_code != SUCCESS_CODE:
-        return False, messages[3132] + f'{stop_nginx.exit_code}s.'
+    if exit_code != SUCCESS_CODE:
+        return False, messages[3132] + f'{exit_code}s.'
 
     # call rcc comms_ssh for nginx config file removal on disabled PodNet
     try:
-        remove_config, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=disabled,
             payload=remove_config_payload,
             username='robot',
@@ -424,8 +424,8 @@ def scrub(
     except CouldNotConnectException:
         return False, messages[3133]
 
-    if remove_config.exit_code != SUCCESS_CODE:
-        return False, messages[3134]  + f'{remove_config.exit_code}s.'
+    if exit_code != SUCCESS_CODE:
+        return False, messages[3134]  + f'{exit_code}s.'
 
 
     return True, messages[1100]
@@ -588,7 +588,7 @@ def read(
 
     # call rcc comms_ssh for config retrieval from enabled PodNet
     try:
-        read_config, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=enabled,
             payload=read_config_payload,
             username='robot',
@@ -597,15 +597,15 @@ def read(
         retval = False
         message_list.append(messages[3221])
 
-    if read_config.exit_code != SUCCESS_CODE:
+    if exit_code != SUCCESS_CODE:
         retval = False
-        message_list.append(messages[3222] + f'{read_config.exit_code}s.')
+        message_list.append(messages[3222] + f'{exit_code}s.')
 
     data_dict[enabled]['config_file'] = stdout
 
     # call rcc comms_ssh for process_status retrieval from enabled PodNet
     try:
-        read_process_status, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=enabled,
             payload=find_process_payload,
             username='robot',
@@ -614,15 +614,15 @@ def read(
         retval = False
         message_list.append(messages[3223])
 
-    if read_process_status.exit_code != SUCCESS_CODE:
+    if exit_code != SUCCESS_CODE:
         retval = False
-        message_list.append(messages[3224]  + f'{read_process_status.exit_code}s.')
+        message_list.append(messages[3224]  + f'{exit_code}s.')
 
     data_dict[enabled]['process_status'] = stdout
 
     # call rcc comms_ssh for config retrieval from disabled PodNet
     try:
-        read_config, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=disabled,
             payload=read_config_payload,
             username='robot',
@@ -631,15 +631,15 @@ def read(
         retval = False
         message_list.append(messages[3231])
 
-    if read_config.exit_code != SUCCESS_CODE:
+    if exit_code != SUCCESS_CODE:
         retval = False
-        message_list.append(messages[3232] + f'{read_config.exit_code}s.')
+        message_list.append(messages[3232] + f'{exit_code}s.')
 
     data_dict[enabled]['config_file'] = stdout
 
     # call rcc comms_ssh for process_status retrieval from disabled PodNet
     try:
-        read_process_status, stdout, stderr = comms_ssh(
+        exit_code, stdout, stderr = comms_ssh(
             host_ip=disabled,
             payload=find_process_payload,
             username='robot',
@@ -648,9 +648,9 @@ def read(
         retval = False
         message_list.append(messages[3233])
 
-    if read_process_status.exit_code != SUCCESS_CODE:
+    if exit_code != SUCCESS_CODE:
         retval = False
-        message_list.append(messages[3234]  + f'{read_process_status.exit_code}s.')
+        message_list.append(messages[3234]  + f'{exit_code}s.')
 
     data_dict[enabled]['process_status'] = stdout
 

--- a/nginxns.py
+++ b/nginxns.py
@@ -51,8 +51,8 @@ def build(
         type: tuple
     """
 
-    nginx_config_path = '/etc/netns/{namespace}/nginx.conf'
-    pidfile= '/etc/netns/{namespace}/nginx.pid'
+    nginx_config_path = f'/etc/netns/{namespace}/nginx.conf'
+    pidfile= f'/etc/netns/{namespace}/nginx.pid'
 
     # Define message
     messages = {
@@ -534,8 +534,8 @@ def read(
               type: string
     """
 
-    nginx_config_path = '/etc/netns/{namespace}/nginx.conf'
-    pidfile = '/etc/netns/{namespace}/nginx.conf'
+    nginx_config_path = f'/etc/netns/{namespace}/nginx.conf'
+    pidfile = f'/etc/netns/{namespace}/nginx.conf'
 
     # Define message
     messages = {

--- a/nginxns.py
+++ b/nginxns.py
@@ -579,6 +579,7 @@ def read(
         retval = False
         message_list.append(messages[3217])
     else:
+        message_list.append(messages[3218])
         return retval, data_dict, message_list
 
     # define payloads

--- a/nginxns.py
+++ b/nginxns.py
@@ -166,9 +166,9 @@ def build(
     except CouldNotConnectException:
         return False, messages[3020]
 
-    reload_nginx_payload_enabled = None
+    reload_nginx_payload = None
     if (existing_process.exit_code == SUCCESS_CODE) and (stdout != ""):
-        reload_nginx_payload_enabled = f'kill -HUP {stdout}s'
+        reload_nginx_payload = f'kill -HUP {stdout}s'
     else:
        return False, messages[3021] + f'{existing_process.exit_code}s.'
 

--- a/nginxns.py
+++ b/nginxns.py
@@ -594,10 +594,11 @@ def read(
             username='robot',
         )
     except CouldNotConnectException:
+        exit_code = None
         retval = False
         message_list.append(messages[3221])
 
-    if exit_code != SUCCESS_CODE:
+    if ( exit_code is not None ) and ( exit_code != SUCCESS_CODE ):
         retval = False
         message_list.append(messages[3222] + f'{exit_code}s.')
 
@@ -611,10 +612,11 @@ def read(
             username='robot',
         )
     except CouldNotConnectException:
+        exit_code = None
         retval = False
         message_list.append(messages[3223])
 
-    if exit_code != SUCCESS_CODE:
+    if ( exit_code is not None ) and ( exit_code != SUCCESS_CODE ):
         retval = False
         message_list.append(messages[3224]  + f'{exit_code}s.')
 
@@ -628,10 +630,11 @@ def read(
             username='robot',
         )
     except CouldNotConnectException:
+        exit_code = None
         retval = False
         message_list.append(messages[3231])
 
-    if exit_code != SUCCESS_CODE:
+    if ( exit_code is not None ) and ( exit_code != SUCCESS_CODE ):
         retval = False
         message_list.append(messages[3232] + f'{exit_code}s.')
 
@@ -645,10 +648,11 @@ def read(
             username='robot',
         )
     except CouldNotConnectException:
+        exit_code = None
         retval = False
         message_list.append(messages[3233])
 
-    if exit_code != SUCCESS_CODE:
+    if ( exit_code is not None ) and ( exit_code != SUCCESS_CODE ):
         retval = False
         message_list.append(messages[3234]  + f'{exit_code}s.')
 

--- a/templates/nginxns/nginx.conf.j2
+++ b/templates/nginxns/nginx.conf.j2
@@ -1,6 +1,6 @@
 user www-data;
 worker_processes auto;
-pid pidfile;
+pid {{pidfile}};
 include /etc/nginx/modules-enabled/*.conf;
 
 events {

--- a/templates/nginxns/nginx.conf.j2
+++ b/templates/nginxns/nginx.conf.j2
@@ -1,6 +1,6 @@
 user www-data;
 worker_processes auto;
-pid /run/nginx-{{ namespace }}.pid;
+pid pidfile;
 include /etc/nginx/modules-enabled/*.conf;
 
 events {

--- a/templates/nginxns/nginx.conf.j2
+++ b/templates/nginxns/nginx.conf.j2
@@ -1,0 +1,17 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx-{{ namespace }}.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+}
+
+http {
+    server {
+        server_name ci-data;
+        listen 169.254.169.254:80;
+        location / {
+            root /etc/netns/{{namespace}}/cloudcix-metadata/$remote_addr/;
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a nginxns prototype for starting the nginx server serving cloud-init metadata and userdata from the PodNet node's project network namespace.

As usual, there is a little food for discussion in here. Namely, I modified the read() function's contract in several ways:

1) It does not fail hard and early.

2) It returns a tuple of 3 values instead of 2. (boolean: status, dict: data, list: messages)

3) It gathers all error messages it encounters along the way and returns these as a list at the end instead of failing early as soon as it encounters the first error. I believe this is the better approach for a read() function because it should return as much useful debugging information as possible rather than only tell us its first stumbling block.