### PR TITLE
Add ns primitive

### DIFF
--- a/directorymain.py
+++ b/directorymain.py
@@ -124,7 +124,7 @@ def build(
         return False, messages[3021]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3022]
+        return False, f'{messages[3022]}\nExit Code: {exit_code}\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     # call rcc comms_ssh on disabled PodNet
     try:
@@ -137,7 +137,7 @@ def build(
         return False, messages[3031]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3032]
+        return False, f'{messages[3032]}\nExit Code: {exit_code}\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     return True, messages[1000]
 
@@ -245,7 +245,7 @@ def read(
         return False, messages[3021]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3022]
+        return False, f'{messages[3022]}\nExit Code: {exit_code}\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     # call rcc comms_ssh on disabled PodNet
     try:
@@ -258,7 +258,7 @@ def read(
         return False, messages[3031]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3032]
+        return False, f'{messages[3032]}\nExit Code: {exit_code}\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     return True, messages[1000]
 
@@ -366,7 +366,7 @@ def scrub(
         return False, messages[3021]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3022]
+        return False, f'{messages[3022]}\nExit Code: {exit_code}\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     # call rcc comms_ssh on disabled PodNet
     try:
@@ -379,6 +379,6 @@ def scrub(
         return False, messages[3031]
 
     if exit_code != SUCCESS_CODE:
-        return False, messages[3032]
+        return False, f'{messages[3032]}\nExit Code: {exit_code}\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
     return True, messages[1000]

--- a/ns.py
+++ b/ns.py
@@ -146,7 +146,7 @@ def build(
         return False, messages[3021] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
 
     create_namespace = True
-    if ret["exit_code"] == SUCCESS_CODE:
+    if ret["payload_code"] == SUCCESS_CODE:
         # No need to create this name space if it exists already
         create_namespace = False
 
@@ -159,8 +159,8 @@ def build(
       )
       if ret["channel_code"] != CHANNEL_SUCCESS:
           return False, messages[3022] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
-      if ret["exit_code"] != SUCCESS_CODE:
-          return False, messages[3023]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+      if ret["payload_code"] != SUCCESS_CODE:
+          return False, messages[3023]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on enabled PodNet to enable IPv4 forwarding
     ret = comms_ssh(
@@ -170,8 +170,8 @@ def build(
     )
     if ret["channel_code"] != CHANNEL_SUCCESS:
         return False, messages[3024] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
-    if ret["exit_code"] != SUCCESS_CODE:
-        return False, messages[3025]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+    if ret["payload_code"] != SUCCESS_CODE:
+        return False, messages[3025]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on enabled PodNet to enable IPv6 forwarding
     ret = comms_ssh(
@@ -181,8 +181,8 @@ def build(
     )
     if ret["channel_code"] != CHANNEL_SUCCESS:
         return False, messages[3026] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
-    if ret["exit_code"] != SUCCESS_CODE:
-        return False, messages[3027]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+    if ret["payload_code"] != SUCCESS_CODE:
+        return False, messages[3027]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on disabled PodNet to find name space
     ret = comms_ssh(
@@ -194,7 +194,7 @@ def build(
         return False, messages[3031] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
 
     create_namespace = True
-    if ret["exit_code"] == SUCCESS_CODE:
+    if ret["payload_code"] == SUCCESS_CODE:
         # No need to create this name space if it exists already
         create_namespace = False
 
@@ -207,8 +207,8 @@ def build(
       )
       if ret["channel_code"] != CHANNEL_SUCCESS:
           return False, messages[3032] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
-      if ret["exit_code"] != SUCCESS_CODE:
-          return False, messages[3033]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+      if ret["payload_code"] != SUCCESS_CODE:
+          return False, messages[3033]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on disabled PodNet to enable IPv4 forwarding
     ret = comms_ssh(
@@ -218,8 +218,8 @@ def build(
     )
     if ret["channel_code"] != CHANNEL_SUCCESS:
         return False, messages[3034] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
-    if ret["exit_code"] != SUCCESS_CODE:
-        return False, messages[3035]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+    if ret["payload_code"] != SUCCESS_CODE:
+        return False, messages[3035]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on disabled PodNet to enable IPv6 forwarding
     ret = comms_ssh(
@@ -229,8 +229,8 @@ def build(
     )
     if ret["channel_code"] != CHANNEL_SUCCESS:
         return False, messages[3036] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
-    if ret["exit_code"] != SUCCESS_CODE:
-        return False, messages[3037]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+    if ret["payload_code"] != SUCCESS_CODE:
+        return False, messages[3037]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     return True, messages[1000]
 
@@ -341,7 +341,7 @@ def scrub(
         return False, messages[3121] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
 
     delete_namespace = False
-    if ret["exit_code"] == SUCCESS_CODE:
+    if ret["payload_code"] == SUCCESS_CODE:
         # No need to delete this name space if it exists already
         delete_namespace = True
 
@@ -354,8 +354,8 @@ def scrub(
       )
       if ret["channel_code"] != CHANNEL_SUCCESS:
           return False, messages[3122] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
-      if ret["exit_code"] != SUCCESS_CODE:
-          return False, messages[3123]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+      if ret["payload_code"] != SUCCESS_CODE:
+          return False, messages[3123]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on disabled PodNet
     ret = comms_ssh(
@@ -367,8 +367,8 @@ def scrub(
         return False, messages[3131] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
 
     delete_namespace = False
-    if ret["exit_code"] == SUCCESS_CODE:
-        # No need to delete this name space if it exists already
+    if ret["payload_code"] == SUCCESS_CODE:
+        # Only delete this name space if it exists
         delete_namespace = True
 
     if delete_namespace:
@@ -380,8 +380,8 @@ def scrub(
       )
       if ret["channel_code"] != CHANNEL_SUCCESS:
           return False, messages[3132] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
-      if ret["exit_code"] != SUCCESS_CODE:
-          return False, messages[3133]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+      if ret["payload_code"] != SUCCESS_CODE:
+          return False, messages[3133]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     return True, messages[1000]
 
@@ -555,9 +555,9 @@ def read(
         retval = False
         message_list.append(messages[3221] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
+    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3222] + f'{exit_code}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
+        message_list.append(messages[3222] + f'{payload_code}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
         data_dict[enabled]['entry'] = ret["payload_message"]
 
@@ -571,9 +571,9 @@ def read(
         retval = False
         message_list.append(messages[3223] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
+    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3224] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
+        message_list.append(messages[3224] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
         if ret["payload_message"] != '1':
             retval = False
@@ -590,9 +590,9 @@ def read(
         retval = False
         message_list.append(messages[3226] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
+    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3227] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
+        message_list.append(messages[3227] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
         if ret["payload_message"] != '1':
             retval = False
@@ -609,9 +609,9 @@ def read(
         retval = False
         message_list.append(messages[3231] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
+    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3232] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
+        message_list.append(messages[3232] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
         data_dict[disabled]['entry'] = ret["payload_message"]
 
@@ -625,9 +625,9 @@ def read(
         retval = False
         message_list.append(messages[3233] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
+    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3234] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
+        message_list.append(messages[3234] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
         if ret["payload_message"] != '1':
             retval = False
@@ -644,9 +644,9 @@ def read(
         retval = False
         message_list.append(messages[3236] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
+    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3237] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
+        message_list.append(messages[3237] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
         if ret["payload_message"] != '1':
             retval = False

--- a/ns.py
+++ b/ns.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Tuple
 # lib
 from cloudcix.rcc import comms_ssh, CHANNEL_SUCCESS, VALIDATION_ERROR, CONNECTION_ERROR
+from utils import load_pod_config
 # local
 
 
@@ -57,15 +58,6 @@ def build(
     messages = {
         1000: f'1000: Successfully created network name space {name} on both PodNet nodes.',
         1001: f'1001: Success: name space {name} exists already',
-        2111: f'2011: Config file {config_file} loaded.',
-        3011: f'3011: Failed to load config file {config_file}, It does not exist.',
-        3012: f'3012: Failed to get `ipv6_subnet` from config file {config_file}',
-        3013: f'3013: Invalid value for `ipv6_subnet` from config file {config_file}',
-        3014: f'3014: Failed to get `podnet_a_enabled` from config file {config_file}',
-        3015: f'3015: Failed to get `podnet_b_enabled` from config file {config_file}',
-        3016: f'3016: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
-        3017: f'3017: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
-        3018: f'3018: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
         3021: f'3021: Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace_payload: ',
         3022: f'3022: Failed to connect to the enabled PodNet from the config file {config_file} for create_namespace_payload: ',
         3023: f'3023: Failed to create name space {name} on the enabled PodNet. Payload exited with status ',
@@ -109,51 +101,16 @@ def build(
         3067: f'3067: Failed to run enable_lo1_payload on the disabled PodNet from the config file {config_file}. Payload exited with status ',
     }
 
-    # Default config_file if it is None
-    if config_file is None:
-        config_file = '/opt/robot/config.json'
-
-    # Get load config from config_file
-    if not Path(config_file).exists():
-        return False, messages[3011]
-    with Path(config_file).open('r') as file:
-        config = json.load(file)
-
-    # Get the ipv6_subnet from config_file
-    ipv6_subnet = config.get('ipv6_subnet', None)
-    if ipv6_subnet is None:
-        return False, messages[3012]
-    # Verify the ipv6_subnet value
-    try:
-        ipaddress.ip_network(ipv6_subnet)
-    except ValueError:
-        return False, messages[3013]
-
-    # Get the PodNet Mgmt ips from ipv6_subnet
-    podnet_a = f'{ipv6_subnet.split("/")[0]}10:0:2'
-    podnet_b = f'{ipv6_subnet.split("/")[0]}10:0:3'
-
-    # Get `podnet_a_enabled` and `podnet_b_enabled`
-    podnet_a_enabled = config.get('podnet_a_enabled', None)
-    if podnet_a_enabled is None:
-        return False, messages[3014]
-    podnet_b_enabled = config.get('podnet_b_enabled', None)
-    if podnet_a_enabled is None:
-        return False, messages[3015]
-
-    # First run on enabled PodNet
-    if podnet_a_enabled is True and podnet_b_enabled is False:
-        enabled = podnet_a
-        disabled = podnet_b
-    elif podnet_a_enabled is False and podnet_b_enabled is True:
-        enabled = podnet_b
-        disabled = podnet_a
-    elif podnet_a_enabled is True and podnet_b_enabled is True:
-        return False, messages[3016]
-    elif podnet_a_enabled is False and podnet_b_enabled is False:
-        return False, messages[3017]
-    else:
-        return False, messages[3018]
+    status, config_data, msg = load_pod_config(config_file)
+    if not status:
+      if config_data['raw'] is None:
+          return False, msg
+      else:
+          return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
+              indent=2,
+              sort_keys=True)
+    enabled = config_data['processed']['enabled']
+    disabled = config_data['processed']['enabled']
 
     name_grepsafe = name.replace('.', '\.')
     lo_addr_grepsafe = lo_addr.replace('.', '\.')
@@ -454,15 +411,6 @@ def scrub(
 
     messages = {
         1100: f'1100: Successfully removed name space {name} from both PodNet nodes.',
-        2111: f'2111: Config file {config_file} loaded.',
-        3111: f'3111: Failed to load config file {config_file}, It does not exist.',
-        3112: f'3112: Failed to get `ipv6_subnet` from config file {config_file}',
-        3113: f'3113: Invalid value for `ipv6_subnet` from config file {config_file}',
-        3114: f'3114: Failed to get `podnet_a_enabled` from config file {config_file}',
-        3115: f'3115: Failed to get `podnet_b_enabled` from config file {config_file}',
-        3116: f'3116: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
-        3117: f'3117: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
-        3118: f'3118: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
         3121: f'3121: Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace_payload: ',
         3122: f'3122: Failed to connect to the enabled PodNet from the config file {config_file} for delete_namespace_payload: ',
         3123: f'3123: Failed to delete name space {name} on the enabled PodNet. Payload exited with status ',
@@ -474,51 +422,16 @@ def scrub(
                'Payload exited with status ',
     }
 
-    # Default config_file if it is None
-    if config_file is None:
-        config_file = '/opt/robot/config.json'
-
-    # Get load config from config_file
-    if not Path(config_file).exists():
-        return False, messages[3111]
-    with Path(config_file).open('r') as file:
-        config = json.load(file)
-
-    # Get the ipv6_subnet from config_file
-    ipv6_subnet = config.get('ipv6_subnet', None)
-    if ipv6_subnet is None:
-        return False, messages[3112]
-    # Verify the ipv6_subnet value
-    try:
-        ipaddress.ip_network(ipv6_subnet)
-    except ValueError:
-        return False, messages[3113]
-
-    # Get the PodNet Mgmt ips from ipv6_subnet
-    podnet_a = f'{ipv6_subnet.split("/")[0]}10:0:2'
-    podnet_b = f'{ipv6_subnet.split("/")[0]}10:0:3'
-
-    # Get `podnet_a_enabled` and `podnet_b_enabled`
-    podnet_a_enabled = config.get('podnet_a_enabled', None)
-    if podnet_a_enabled is None:
-        return False, messages[3114]
-    podnet_b_enabled = config.get('podnet_b_enabled', None)
-    if podnet_a_enabled is None:
-        return False, messages[3115]
-
-    # First run on enabled PodNet
-    if podnet_a_enabled is True and podnet_b_enabled is False:
-        enabled = podnet_a
-        disabled = podnet_b
-    elif podnet_a_enabled is False and podnet_b_enabled is True:
-        enabled = podnet_b
-        disabled = podnet_a
-    elif podnet_a_enabled is True and podnet_b_enabled is True:
-        return False, messages[3116]
-    elif podnet_a_enabled is False and podnet_b_enabled is False:
-        return False, messages[3117]
-    else:
-        return False, messages[3118]
+    status, config_data, msg = load_pod_config(config_file)
+    if not status:
+      if config_data['raw'] is None:
+          return False, msg
+      else:
+          return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
+              indent=2,
+              sort_keys=True)
+    enabled = config_data['processed']['enabled']
+    disabled = config_data['processed']['enabled']
 
     name_grepsafe = name.replace('.', '\.')
 
@@ -640,15 +553,6 @@ def read(
 
     messages = {
         1200: f'1200: Successfully retrieved network name space {name} status from both PodNet nodes.',
-        2211: f'2211: Config file {config_file} loaded.',
-        3211: f'3211: Failed to load config file {config_file}, It does not exist.',
-        3212: f'3212: Failed to get `ipv6_subnet` from config file {config_file}',
-        3213: f'3213: Invalid value for `ipv6_subnet` from config file {config_file}',
-        3214: f'3214: Failed to get `podnet_a_enabled` from config file {config_file}',
-        3215: f'3215: Failed to get `podnet_b_enabled` from config file {config_file}',
-        3216: f'3216: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
-        3217: f'3217: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
-        3218: f'3218: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
         3221: f'3221: Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace_payload: ',
         3222: f'3222: Failed to find name space {name} on the enabled PodNet. Payload exited with status ',
         3223: f'3223: Failed to connect to the enabled PodNet from the config file {config_file} for find_forwardv4_payload',
@@ -671,71 +575,16 @@ def read(
     data_dict = None
     message_list = ()
 
-    # Default config_file if it is None
-    if config_file is None:
-        config_file = '/opt/robot/config.json'
-
-    # Get load config from config_file
-    if not Path(config_file).exists():
-        retval = False
-        message_list.append(messages[3211])
-    with Path(config_file).open('r') as file:
-        config = json.load(file)
-
-    # Get the ipv6_subnet from config_file
-    ipv6_subnet = config.get('ipv6_subnet', None)
-    if ipv6_subnet is None:
-        retval = False
-        message_list.append(messages[3212])
-    # Verify the ipv6_subnet value
-    try:
-        ipaddress.ip_network(ipv6_subnet)
-    except ValueError:
-        retval = False
-        message_list.append(messages[3213])
-
-    # Get the PodNet Mgmt ips from ipv6_subnet
-    podnet_a = f'{ipv6_subnet.split("/")[0]}10:0:2'
-    podnet_b = f'{ipv6_subnet.split("/")[0]}10:0:3'
-
-    data_dict = {}
-
-    data_dict[podnet_a] = {
-        'entry': None,
-    }
-
-    data_dict[podnet_b] = {
-        'entry': None,
-    }
-
-    # Get `podnet_a_enabled` and `podnet_b_enabled`
-    podnet_a_enabled = config.get('podnet_a_enabled', None)
-    if podnet_a_enabled is None:
-        retval = False
-        message_list.append(messages[3214])
-    podnet_b_enabled = config.get('podnet_b_enabled', None)
-    if podnet_a_enabled is None:
-        retval = False
-        message_list.append(messages[3215])
-
-    # First run on enabled PodNet
-    if podnet_a_enabled is True and podnet_b_enabled is False:
-        enabled = podnet_a
-        disabled = podnet_b
-    elif podnet_a_enabled is False and podnet_b_enabled is True:
-        enabled = podnet_b
-        disabled = podnet_a
-    elif podnet_a_enabled is True and podnet_b_enabled is True:
-        retval = False
-        message_list.append(messages[3216])
-    elif podnet_a_enabled is False and podnet_b_enabled is False:
-        retval = False
-        message_list.append(messages[3217])
-    else:
-        message_list.append(messages[3218])
-
-    if retval == False:
-        return retval, data_dict, message_list
+    status, config_data, msg = load_pod_config(config_file)
+    if not status:
+      if config_data['raw'] is None:
+          return False, msg
+      else:
+          return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
+              indent=2,
+              sort_keys=True)
+    enabled = config_data['processed']['enabled']
+    disabled = config_data['processed']['enabled']
 
     name_grepsafe = name.replace('.', '\.')
 

--- a/ns.py
+++ b/ns.py
@@ -137,100 +137,100 @@ def build(
     enable_forwardv6_payload = "ip netns exec {name} sysctl --write net.ipv6.conf.all.forwarding=1"
 
     # call rcc comms_ssh on enabled PodNet
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=enabled,
         payload=find_namespace_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3021] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
+    if ret["channel_code"] != CHANNEL_SUCCESS:
+        return False, messages[3021] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
 
     create_namespace = True
-    if exit_code == SUCCESS_CODE:
+    if ret["exit_code"] == SUCCESS_CODE:
         # No need to create this name space if it exists already
         create_namespace = False
 
     if create_namespace:
       # call rcc comms_ssh on enabled PodNet
-      channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+      ret = comms_ssh(
           host_ip=enabled,
           payload=create_namespace_payload,
           username='robot',
       )
-      if channel_code != CHANNEL_SUCCESS:
-          return False, messages[3022] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
-      if exit_code != SUCCESS_CODE:
-          return False, messages[3023]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+      if ret["channel_code"] != CHANNEL_SUCCESS:
+          return False, messages[3022] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
+      if ret["exit_code"] != SUCCESS_CODE:
+          return False, messages[3023]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on enabled PodNet to enable IPv4 forwarding
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=enabled,
         payload=enable_forwardv4_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3024] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
-    if exit_code != SUCCESS_CODE:
-        return False, messages[3025]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+    if ret["channel_code"] != CHANNEL_SUCCESS:
+        return False, messages[3024] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
+    if ret["exit_code"] != SUCCESS_CODE:
+        return False, messages[3025]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on enabled PodNet to enable IPv6 forwarding
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=enabled,
         payload=enable_forwardv6_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3026] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
-    if exit_code != SUCCESS_CODE:
-        return False, messages[3027]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+    if ret["channel_code"] != CHANNEL_SUCCESS:
+        return False, messages[3026] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
+    if ret["exit_code"] != SUCCESS_CODE:
+        return False, messages[3027]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on disabled PodNet to find name space
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=disabled,
         payload=find_namespace_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3031] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
+    if ret["channel_code"] != CHANNEL_SUCCESS:
+        return False, messages[3031] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
 
     create_namespace = True
-    if exit_code == SUCCESS_CODE:
+    if ret["exit_code"] == SUCCESS_CODE:
         # No need to create this name space if it exists already
         create_namespace = False
 
     if create_namespace:
       # call rcc comms_ssh on disabled PodNet to create name space
-      channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+      ret = comms_ssh(
           host_ip=disabled,
           payload=create_namespace_payload,
           username='robot',
       )
-      if channel_code != CHANNEL_SUCCESS:
-          return False, messages[3032] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
-      if exit_code != SUCCESS_CODE:
-          return False, messages[3033]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+      if ret["channel_code"] != CHANNEL_SUCCESS:
+          return False, messages[3032] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
+      if ret["exit_code"] != SUCCESS_CODE:
+          return False, messages[3033]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on disabled PodNet to enable IPv4 forwarding
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=disabled,
         payload=enable_forwardv4_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3034] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
-    if exit_code != SUCCESS_CODE:
-        return False, messages[3035]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+    if ret["channel_code"] != CHANNEL_SUCCESS:
+        return False, messages[3034] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
+    if ret["exit_code"] != SUCCESS_CODE:
+        return False, messages[3035]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on disabled PodNet to enable IPv6 forwarding
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=disabled,
         payload=enable_forwardv6_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3036] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
-    if exit_code != SUCCESS_CODE:
-        return False, messages[3037]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+    if ret["channel_code"] != CHANNEL_SUCCESS:
+        return False, messages[3036] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
+    if ret["exit_code"] != SUCCESS_CODE:
+        return False, messages[3037]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     return True, messages[1000]
 
@@ -332,56 +332,56 @@ def scrub(
     delete_namespace_payload = "ip netns delete {name}"
 
     # call rcc comms_ssh on enabled PodNet
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=enabled,
         payload=find_namespace_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3121] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
+    if ret["channel_code"] != CHANNEL_SUCCESS:
+        return False, messages[3121] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
 
     delete_namespace = False
-    if exit_code == SUCCESS_CODE:
+    if ret["exit_code"] == SUCCESS_CODE:
         # No need to delete this name space if it exists already
         delete_namespace = True
 
     if delete_namespace:
       # call rcc comms_ssh on enabled PodNet
-      channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+      ret = comms_ssh(
           host_ip=enabled,
           payload=delete_namespace_payload,
           username='robot',
       )
-      if channel_code != CHANNEL_SUCCESS:
-          return False, messages[3122] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
-      if exit_code != SUCCESS_CODE:
-          return False, messages[3123]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+      if ret["channel_code"] != CHANNEL_SUCCESS:
+          return False, messages[3122] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
+      if ret["exit_code"] != SUCCESS_CODE:
+          return False, messages[3123]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     # call rcc comms_ssh on disabled PodNet
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=disabled,
         payload=find_namespace_payload,
         username='robot',
     )
     if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3131] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
+        return False, messages[3131] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
 
     delete_namespace = False
-    if exit_code == SUCCESS_CODE:
+    if ret["exit_code"] == SUCCESS_CODE:
         # No need to delete this name space if it exists already
         delete_namespace = True
 
     if delete_namespace:
       # call rcc comms_ssh on disabled PodNet
-      channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+      ret = comms_ssh(
           host_ip=disabled,
           payload=delete_namespace_payload,
           username='robot',
       )
-      if channel_code != CHANNEL_SUCCESS:
-          return False, messages[3132] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
-      if exit_code != SUCCESS_CODE:
-          return False, messages[3133]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+      if ret["channel_code"] != CHANNEL_SUCCESS:
+          return False, messages[3132] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}'
+      if ret["exit_code"] != SUCCESS_CODE:
+          return False, messages[3133]  + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
 
     return True, messages[1000]
 
@@ -545,113 +545,113 @@ def read(
     find_forwardv6_payload = "ip netns exec {name} sysctl --write net.ipv6.conf.all.forwarding | awk {print $3}'"
 
     # call rcc comms_ssh for name space retrieval from enabled PodNet
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=enabled,
         payload=find_namespace_payload,
         username='robot',
     )
 
-    if channel_code != CHANNEL_SUCCESS:
+    if ret["channel_code"] != CHANNEL_SUCCESS:
         retval = False
-        message_list.append(messages[3221] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}')
+        message_list.append(messages[3221] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (exit_code is not None) and (exit_code != SUCCESS_CODE):
+    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3222] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
+        message_list.append(messages[3222] + f'{exit_code}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
-        data_dict[enabled]['entry'] = stdout
+        data_dict[enabled]['entry'] = ret["payload_message"]
 
     # call rcc comms_ssh for IPv4 forwarding status retrieval from enabled PodNet
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=enabled,
         payload=find_forwardv4_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
+    if ret["channel_code"] != CHANNEL_SUCCESS:
         retval = False
-        message_list.append(messages[3223] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}')
+        message_list.append(messages[3223] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (exit_code is not None) and (exit_code != SUCCESS_CODE):
+    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3224] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
+        message_list.append(messages[3224] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
-        if stdout != '1':
+        if ret["payload_message"] != '1':
             retval = False
-            message_list.append(messages[3225] + f'(is: {stdout}s, should be: `1`).')
-        data_dict[enabled]['forwardv4'] = stdout
+            message_list.append(messages[3225] + f'(is: {ret["payload_message"]}s, should be: `1`).')
+        data_dict[enabled]['forwardv4'] = ret["payload_message"]
 
     # call rcc comms_ssh for IPv6 forwarding status retrieval from enabled PodNet
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=enabled,
         payload=find_forwardv6_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
+    if ret["channel_code"] != CHANNEL_SUCCESS:
         retval = False
-        message_list.append(messages[3226] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}')
+        message_list.append(messages[3226] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (exit_code is not None) and (exit_code != SUCCESS_CODE):
+    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3227] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
+        message_list.append(messages[3227] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
-        if stdout != '1':
+        if ret["payload_message"] != '1':
             retval = False
-            message_list.append(messages[3228] + f'(is: {stdout}s, should be: `1`).')
-        data_dict[enabled]['forwardv6'] = stdout
+            message_list.append(messages[3228] + f'(is: {ret["payload_message"]}s, should be: `1`).')
+        data_dict[enabled]['forwardv6'] = ret["payload_message"]
 
     # call rcc comms_ssh for name space retrieval from disabled PodNet
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=disabled,
         payload=find_namespace_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
+    if ret["channel_code"] != CHANNEL_SUCCESS:
         retval = False
-        message_list.append(messages[3231] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}')
+        message_list.append(messages[3231] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (exit_code is not None) and (exit_code != SUCCESS_CODE):
+    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3232] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
+        message_list.append(messages[3232] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
-        data_dict[disabled]['entry'] = stdout
+        data_dict[disabled]['entry'] = ret["payload_message"]
 
     # call rcc comms_ssh for IPv4 forwarding status retrieval from disabled PodNet
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=disabled,
         payload=find_forwardv4_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
+    if ret["channel_code"] != CHANNEL_SUCCESS:
         retval = False
-        message_list.append(messages[3233] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}')
+        message_list.append(messages[3233] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (exit_code is not None) and (exit_code != SUCCESS_CODE):
+    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3234] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
+        message_list.append(messages[3234] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
-        if stdout != '1':
+        if ret["payload_message"] != '1':
             retval = False
-            message_list.append(messages[3235] + f'(is: {stdout}s, should be: `1`).')
-        data_dict[disabled]['forwardv4'] = stdout
+            message_list.append(messages[3235] + f'(is: {ret["payload_message"]}s, should be: `1`).')
+        data_dict[disabled]['forwardv4'] = ret["payload_message"]
 
     # call rcc comms_ssh for IPv6 forwarding status retrieval from disabled PodNet
-    channel_code, channel_error, channel_message, exit_code, stdout, stderr = comms_ssh(
+    ret = comms_ssh(
         host_ip=disabled,
         payload=find_forwardv6_payload,
         username='robot',
     )
-    if channel_code != CHANNEL_SUCCESS:
+    if ret["channel_code"] != CHANNEL_SUCCESS:
         retval = False
-        message_list.append(messages[3236] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}')
+        message_list.append(messages[3236] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {channel_message}\nchannel_error: {ret["channel_error"]}')
 
-    if (exit_code is not None) and (exit_code != SUCCESS_CODE):
+    if (ret["exit_code"] is not None) and (ret["exit_code"] != SUCCESS_CODE):
         retval = False
-        message_list.append(messages[3237] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
+        message_list.append(messages[3237] + f'{ret["exit_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
     else:
-        if stdout != '1':
+        if ret["payload_message"] != '1':
             retval = False
-            message_list.append(messages[3238] + f'(is: {stdout}s, should be: `1`).')
-        data_dict[disabled]['forwardv6'] = stdout
+            message_list.append(messages[3238] + f'(is: {ret["payload_message"]}s, should be: `1`).')
+        data_dict[disabled]['forwardv6'] = ret["payload_message"]
 
     message_list.append(messages[1200])
     return retval, data_dict, message_list

--- a/ns.py
+++ b/ns.py
@@ -143,7 +143,7 @@ def build(
         username='robot',
     )
     if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3021 + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}']
+        return False, messages[3021] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
 
     create_namespace = True
     if exit_code == SUCCESS_CODE:
@@ -158,7 +158,7 @@ def build(
           username='robot',
       )
       if channel_code != CHANNEL_SUCCESS:
-          return False, messages[3022 + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}']
+          return False, messages[3022] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
       if exit_code != SUCCESS_CODE:
           return False, messages[3023]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
@@ -169,7 +169,7 @@ def build(
         username='robot',
     )
     if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3024 + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}']
+        return False, messages[3024] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
     if exit_code != SUCCESS_CODE:
         return False, messages[3025]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
@@ -180,7 +180,7 @@ def build(
         username='robot',
     )
     if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3026 + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}']
+        return False, messages[3026] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
     if exit_code != SUCCESS_CODE:
         return False, messages[3027]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
@@ -191,7 +191,7 @@ def build(
         username='robot',
     )
     if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3031 + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}']
+        return False, messages[3031] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
 
     create_namespace = True
     if exit_code == SUCCESS_CODE:
@@ -206,7 +206,7 @@ def build(
           username='robot',
       )
       if channel_code != CHANNEL_SUCCESS:
-          return False, messages[3032 + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}']
+          return False, messages[3032] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
       if exit_code != SUCCESS_CODE:
           return False, messages[3033]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
@@ -217,7 +217,7 @@ def build(
         username='robot',
     )
     if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3034 + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}']
+        return False, messages[3034] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
     if exit_code != SUCCESS_CODE:
         return False, messages[3035]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 
@@ -228,7 +228,7 @@ def build(
         username='robot',
     )
     if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3036 + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}']
+        return False, messages[3036] + f'channel_code: {channel_code}s.\nchannel_message: {channel_message}\nchannel_error: {channel_error}'
     if exit_code != SUCCESS_CODE:
         return False, messages[3037]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
 

--- a/ns.py
+++ b/ns.py
@@ -61,44 +61,43 @@ def build(
 
     messages = {
         # Enabled Podnet
-        1000: f'1000: Successfully created network name space {name} on both PodNet nodes.',
-        1001: f'1001: Success: name space {name} exists already',
-        3021: f'3021: Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace payload: ',
-        3022: f'3022: Failed to connect to the enabled PodNet from the config file {config_file} for create_namespace payload: ',
-        3023: f'3023: Failed to run create_namespace pyaload on the enabled PodNet. Payload exited with status ',
-        3024: f'3024: Failed to run enable_forwardv4 payload in name space {name} on the enabled PodNet. Payload exited with status ',
-        3025: f'3025: Failed to run enable_forwardv4 payload on enabled PodNet. Payload exited with status ',
-        3026: f'3026: Failed to connect to the enabled PodNet from the config file {config_file} for enable_forwardv6 payload: ',
-        3027: f'3027: Failed to run enable_forwardv6 payload on the enabled PodNet. Payload exited with status ',
-        3028: f'3028: Failed to connect to the enabled PodNet from the config file {config_file} for enable_lo payload: ',
-        3029: f'3029: Failed to run enable_lo payload on the enabled PodNet from the config file {config_file}. Payload exited with status ',
-        3030: f'3030: Failed to connect to the enabled PodNet from the config file {config_file} for find_lo1 payload: ',
-        3031: f'3031: Failed to connect to the enabled PodNet from the config file {config_file} for create_lo1 payload: ',
-        3032: f'3032: Failed to run create_lo1 payload on the enabled PodNet from the config file {config_file}. Payload exited with status ',
-        3033: f'3033: Failed to connect to the enabled PodNet from the config file {config_file} for find_lo1 payload: ',
-        3034: f'3034: Failed to connect to the enabled PodNet from the config file {config_file} for create_lo1_address payload: ',
-        3035: f'3035: Failed to run create_lo1_address payload on the enabled PodNet from the config file {config_file}. Payload exited with status ',
-        3036: f'3036: Failed to connect to the enabled PodNet from the config file {config_file} for enable_lo1 payload: ',
-        3037: f'3037: Failed to run enable_lo1 payload on the enabled PodNet from the config file {config_file}. Payload exited with status ',
+        1000: f'Successfully created network name space {name} on both PodNet nodes.',
+        3021: f'Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace payload: ',
+        3022: f'Failed to connect to the enabled PodNet from the config file {config_file} for create_namespace payload: ',
+        3023: f'Failed to run create_namespace pyaload on the enabled PodNet. Payload exited with status ',
+        3024: f'Failed to run enable_forwardv4 payload in name space {name} on the enabled PodNet. Payload exited with status ',
+        3025: f'Failed to run enable_forwardv4 payload on enabled PodNet. Payload exited with status ',
+        3026: f'Failed to connect to the enabled PodNet from the config file {config_file} for enable_forwardv6 payload: ',
+        3027: f'Failed to run enable_forwardv6 payload on the enabled PodNet. Payload exited with status ',
+        3028: f'Failed to connect to the enabled PodNet from the config file {config_file} for enable_lo payload: ',
+        3029: f'Failed to run enable_lo payload on the enabled PodNet from the config file {config_file}. Payload exited with status ',
+        3030: f'Failed to connect to the enabled PodNet from the config file {config_file} for find_lo1 payload: ',
+        3031: f'Failed to connect to the enabled PodNet from the config file {config_file} for create_lo1 payload: ',
+        3032: f'Failed to run create_lo1 payload on the enabled PodNet from the config file {config_file}. Payload exited with status ',
+        3033: f'Failed to connect to the enabled PodNet from the config file {config_file} for find_lo1 payload: ',
+        3034: f'Failed to connect to the enabled PodNet from the config file {config_file} for create_lo1_address payload: ',
+        3035: f'Failed to run create_lo1_address payload on the enabled PodNet from the config file {config_file}. Payload exited with status ',
+        3036: f'Failed to connect to the enabled PodNet from the config file {config_file} for enable_lo1 payload: ',
+        3037: f'Failed to run enable_lo1 payload on the enabled PodNet from the config file {config_file}. Payload exited with status ',
 
         # Disabled Podnet
-        3051: f'3051: Failed to connect to the disabled PodNet from the config file {config_file} for find_namespace payload: ',
-        3052: f'3052: Failed to connect to the disabled PodNet from the config file {config_file} for create_namespace payload: ',
-        3053: f'3053: Failed to run create_namespace payload on the disabled PodNet. Payload exited with status ',
-        3054: f'3034: Failed to connect to the disabled PodNet from the config file {config_file} for enable_forwardv4 payload: ',
-        3055: f'3055: Failed to run enable_forwardv4 payload on disabled PodNet. Payload exited with status ',
-        3056: f'3056: Failed to connect to the disabled PodNet from the config file {config_file} for enable_forwardv6 payload: ',
-        3057: f'3057: Failed to run enable_forwardv6 payload on disabled PodNet. Payload exited with status ',
-        3058: f'3058: Failed to connect to the disabled PodNet from the config file {config_file} for enable_lo payload: ',
-        3059: f'3059: Failed to run enable_lo payload on the disabled PodNet from the config file {config_file}. Payload exited with status ',
-        3060: f'3060: Failed to connect to the disabled PodNet from the config file {config_file} for find_lo1 payload: ',
-        3061: f'3061: Failed to connect to the disabled PodNet from the config file {config_file} for create_lo1 payload: ',
-        3062: f'3062: Failed to run create_lo1 payload on the disabled PodNet from the config file {config_file}. Payload exited with status ',
-        3063: f'3063: Failed to connect to the disabled PodNet from the config file {config_file} for find_lo1 payload: ',
-        3064: f'3064: Failed to connect to the disabled PodNet from the config file {config_file} for create_lo1_address payload: ',
-        3065: f'3065: Failed to run create_lo1_address payload on the disabled PodNet from the config file {config_file}. Payload exited with status ',
-        3066: f'3066: Failed to connect to the disabled PodNet from the config file {config_file} for enable_lo1 payload: ',
-        3067: f'3067: Failed to run enable_lo1 payload on the disabled PodNet from the config file {config_file}. Payload exited with status ',
+        3051: f'Failed to connect to the disabled PodNet from the config file {config_file} for find_namespace payload: ',
+        3052: f'Failed to connect to the disabled PodNet from the config file {config_file} for create_namespace payload: ',
+        3053: f'Failed to run create_namespace payload on the disabled PodNet. Payload exited with status ',
+        3054: f'Failed to connect to the disabled PodNet from the config file {config_file} for enable_forwardv4 payload: ',
+        3055: f'Failed to run enable_forwardv4 payload on disabled PodNet. Payload exited with status ',
+        3056: f'Failed to connect to the disabled PodNet from the config file {config_file} for enable_forwardv6 payload: ',
+        3057: f'Failed to run enable_forwardv6 payload on disabled PodNet. Payload exited with status ',
+        3058: f'Failed to connect to the disabled PodNet from the config file {config_file} for enable_lo payload: ',
+        3059: f'Failed to run enable_lo payload on the disabled PodNet from the config file {config_file}. Payload exited with status ',
+        3060: f'Failed to connect to the disabled PodNet from the config file {config_file} for find_lo1 payload: ',
+        3061: f'Failed to connect to the disabled PodNet from the config file {config_file} for create_lo1 payload: ',
+        3062: f'Failed to run create_lo1 payload on the disabled PodNet from the config file {config_file}. Payload exited with status ',
+        3063: f'Failed to connect to the disabled PodNet from the config file {config_file} for find_lo1 payload: ',
+        3064: f'Failed to connect to the disabled PodNet from the config file {config_file} for create_lo1_address payload: ',
+        3065: f'Failed to run create_lo1_address payload on the disabled PodNet from the config file {config_file}. Payload exited with status ',
+        3066: f'Failed to connect to the disabled PodNet from the config file {config_file} for enable_lo1 payload: ',
+        3067: f'Failed to run enable_lo1 payload on the disabled PodNet from the config file {config_file}. Payload exited with status ',
     }
 
     status, config_data, msg = load_pod_config(config_file)
@@ -140,7 +139,7 @@ def build(
 
         ret = rcc.run(payloads['find_namespace'])
         if ret["channel_code"] != CHANNEL_SUCCESS:
-            return False, fmt.channel_error(ret, prefix+1)
+            return False, fmt.channel_error(ret, "{prefix+1}: " + messages[prefix+1])
         create_namespace = True
         if ret["payload_code"] == SUCCESS_CODE:
             # No need to create this name space if it exists already
@@ -152,35 +151,35 @@ def build(
             ret = rcc.run(payloads['create_namespace'])
 
             if ret["channel_code"] != CHANNEL_SUCCESS:
-                return False, fmt.channel_error(ret, messages[prefix+2])
+                return False, fmt.channel_error(ret, "{prefix+2}: " + messages[prefix+2])
             if ret["payload_code"] != SUCCESS_CODE:
                 return False, fmt.payload_error(messages[prefix+3])
             fmt.add_successful('create_namespace')
 
         ret = rcc.run(payloads['enable_forwardv4'])
         if ret["channel_code"] != CHANNEL_SUCCESS:
-            return False, fmt.channel_error(ret, messages[prefix+4])
+            return False, fmt.channel_error(ret, "{prefix+4}: " + messages[prefix+4])
         if ret["payload_code"] != SUCCESS_CODE:
-            return False, fmt.payload_error(messages[prefix+5])
+            return False, fmt.payload_error("{prefix+5}: " + messages[prefix+5])
         fmt.add_successful('enable_forwardv4')
 
         ret = rcc.run(payloads['enable_forwardv6'])
         if ret["channel_code"] != CHANNEL_SUCCESS:
-            return False, fmt.channel_error(ret, messages[prefix+6])
+            return False, fmt.channel_error(ret, "{prefix+6}: " + messages[prefix+6])
         if ret["payload_code"] != SUCCESS_CODE:
-            return False, fmt.payload_error(messages[prefix+7])
+            return False, fmt.payload_error("{prefix+7}: " + messages[prefix+7])
         fmt.add_successful('enable_forwardv6')
 
         ret = rcc.run(payloads['enable_lo'])
         if ret["channel_code"] != CHANNEL_SUCCESS:
-            return False, fmt.channel_error(ret, messages[prefix+8])
+            return False, fmt.channel_error(ret, "{prefix+8}: " + messages[prefix+8])
         if ret["payload_code"] != SUCCESS_CODE:
-            return False, fmt.payload_error(messages[prefix+9])
+            return False, fmt.payload_error("{prefix+9}: " + messages[prefix+9])
         fmt.add_successful('enable_lo')
 
         ret = rcc.run(payloads['find_lo1'])
         if ret["channel_code"] != CHANNEL_SUCCESS:
-            return False, fmt.channel_error(ret, messages[prefix+10])
+            return False, fmt.channel_error(ret, "{prefix+10}: " + messages[prefix+10])
         create_lo1 = True
         if ret["payload_code"] != SUCCESS_CODE:
             # No need to create lo1 if it exists already
@@ -190,14 +189,14 @@ def build(
         if create_lo1:
             ret = rcc.run(payloads['create_lo1'])
             if ret["channel_code"] != CHANNEL_SUCCESS:
-                return False, fmt.channel_error(ret, messages[prefix+11])
+                return False, fmt.channel_error(ret, "{prefix+11}: " + messages[prefix+11])
             if ret["payload_code"] != SUCCESS_CODE:
-                return False, fmt.payload_error(messages[prefix+12])
+                return False, fmt.payload_error("{prefix+12}: " + messages[prefix+12])
         fmt.add_successful('create_lo1')
 
         ret = rcc.run(payloads['find_lo1_address'])
         if ret["channel_code"] != CHANNEL_SUCCESS:
-            return False, fmt.channel_error(ret, messages[prefix+13])
+            return False, fmt.channel_error(ret, "{prefix+13}: " + messages[prefix+13])
         create_lo1_address = True
         if ret["payload_code"] != SUCCESS_CODE:
             # No need to assign this address to lo1 if it has been assigned already
@@ -207,26 +206,26 @@ def build(
         if create_lo1_address:
             ret = rcc.run(payloads['create_lo1_address'])
             if ret["channel_code"] != CHANNEL_SUCCESS:
-                return False, fmt.channel_error(ret, messages[prefix+14])
+                return False, fmt.channel_error(ret, "{prefix+14}: " + messages[prefix+14])
             if ret["payload_code"] != SUCCESS_CODE:
-                return False, fmt.payload_error(messages[prefix+15])
+                return False, fmt.payload_error("{prefix+15}: " + messages[prefix+15])
             fmt.add_successful('create_lo1_address')
 
         ret = rcc.run(payloads['enable_lo1'])
         if ret["channel_code"] != CHANNEL_SUCCESS:
-            return False, fmt.channel_error(ret, messages[prefix+16])
+            return False, fmt.channel_error(ret, "{prefix+16}: " + messages[prefix+16])
         if ret["payload_code"] != SUCCESS_CODE:
-            return False, fmt.payload_error(messages[prefix+17])
+            return False, fmt.payload_error("{prefix+17}: " + messages[prefix+17])
         fmt.add_successful('enable_lo1')
 
-        return True, "", successful_payloads
+        return True, "", fmt.successful_payloads
 
 
     status, msg, successful_payloads = run_podnet(enabled, 3020, {})
     if status == False:
         return status, msg
 
-    status, msg = run_podnet(disabled, 3050, successful_payloads)
+    status, msg, successful_payloads = run_podnet(disabled, 3050, successful_payloads)
     if status == False:
         return status, msg
 
@@ -270,16 +269,14 @@ def scrub(
     # Define messages
 
     messages = {
-        1100: f'1100: Successfully removed name space {name} from both PodNet nodes.',
-        3121: f'3121: Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace_payload: ',
-        3122: f'3122: Failed to connect to the enabled PodNet from the config file {config_file} for delete_namespace_payload: ',
-        3123: f'3123: Failed to delete name space {name} on the enabled PodNet. Payload exited with status ',
-        3131: f'3131: Successfully deleted name space {name} on enabled PodNet but failed to connect to the disabled PodNet '
-              f'from the config file {config_file} for find_namespace_payload: ',
-        3132: f'3132: Successfully deleted name space {name} on enabled PodNet but failed to connect to the disabled PodNet '
-              f'from the config file {config_file} for delete_namespace_payload: ',
-        3133: f'3133: Successfully deleted name space {name} on enabled PodNet but failed to delete on the disabled PodNet. '
-               'Payload exited with status ',
+        1100: f'Successfully removed name space {name} from both PodNet nodes.',
+        3121: f'Failed to connect to the enabled PodNet for find_namespace payload: ',
+        3122: f'Failed to connect to the enabled PodNet for delete_namespace_payload: ',
+        3123: f'Failed to run delete_namespace payload on the enabled PodNet. Payload exited with status ',
+
+        3131: f'Failed to connect to the disabled PodNet for find_namespace_payload: ',
+        3132: f'Failed to connect to the disabled PodNet for delete_namespace_payload: ',
+        3133: f'Failed to run delete_namespace payload on the disabled PodNet. Payload exited with status ',
     }
 
     status, config_data, msg = load_pod_config(config_file)
@@ -295,63 +292,51 @@ def scrub(
 
     name_grepsafe = name.replace('.', '\.')
 
-    # define payloads
-    find_namespace_payload = "ip netns list | grep -w '{name_grepsafe}'"
-    delete_namespace_payload = "ip netns delete {name}"
+    def run_podnet(podnet_node, prefix, successful_payloads):
+        rcc = CommsWrapper(comms_ssh, podnet_node, 'robot')
+        fmt = ErrorFormatter(
+            messages,
+            podnet_node,
+            podnet_node == enabled,
+            prefix,
+            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'}
+        )
 
-    # call rcc comms_ssh on enabled PodNet
-    ret = comms_ssh(
-        host_ip=enabled,
-        payload=find_namespace_payload,
-        username='robot',
-    )
-    if ret["channel_code"] != CHANNEL_SUCCESS:
-        return False, messages[3121] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}'
+        payloads = {
+            'find_namespace':     "ip netns list | grep -w '{name_grepsafe}'",
+            'delete_namespace':   "ip netns delete {name}",
+        }
 
-    delete_namespace = False
-    if ret["payload_code"] == SUCCESS_CODE:
-        # No need to delete this name space if it exists already
+        ret = rcc.run(payloads['find_namespace'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, prefix+1)
         delete_namespace = True
+        if ret["payload_code"] == SUCCESS_CODE:
+            # No need to delete this name space if it exists already
+            delete_namespace = False
+        fmt.add_successful('find_namespace')
 
-    if delete_namespace:
-      # call rcc comms_ssh on enabled PodNet
-      ret = comms_ssh(
-          host_ip=enabled,
-          payload=delete_namespace_payload,
-          username='robot',
-      )
-      if ret["channel_code"] != CHANNEL_SUCCESS:
-          return False, messages[3122] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}'
-      if ret["payload_code"] != SUCCESS_CODE:
-          return False, messages[3123]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+        if delete_namespace:
+            # call rcc comms_ssh on enabled PodNet
+            ret = rcc.run(payloads['delete_namespace'])
 
-    # call rcc comms_ssh on disabled PodNet
-    ret = comms_ssh(
-        host_ip=disabled,
-        payload=find_namespace_payload,
-        username='robot',
-    )
-    if channel_code != CHANNEL_SUCCESS:
-        return False, messages[3131] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}'
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, "{prefix+2}: " + messages[prefix+2])
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error("{prefix+3}: " + messages[prefix+3])
+            fmt.add_successful('delete_namespace')
 
-    delete_namespace = False
-    if ret["payload_code"] == SUCCESS_CODE:
-        # Only delete this name space if it exists
-        delete_namespace = True
+        return True, "", fmt.successful_payloads
 
-    if delete_namespace:
-      # call rcc comms_ssh on disabled PodNet
-      ret = comms_ssh(
-          host_ip=disabled,
-          payload=delete_namespace_payload,
-          username='robot',
-      )
-      if ret["channel_code"] != CHANNEL_SUCCESS:
-          return False, messages[3132] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}'
-      if ret["payload_code"] != SUCCESS_CODE:
-          return False, messages[3133]  + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}'
+    status, msg, successful_payloads = run_podnet(enabled, 3120, {})
+    if status == False:
+        return status, msg
 
-    return True, messages[1000]
+    status, msg, successful_payloads = run_podnet(disabled, 3130, successful_payloads)
+    if status == False:
+        return status, msg
+
+    return True, messages[1100]
 
 
 def read(
@@ -381,7 +366,7 @@ def read(
         description: |
             A list with 3 items: (1) a boolean status flag indicating if the
             read was successfull, (2) a dict containing the data as read from
-            the both machines' current state and (3) the output or success message.
+            both machines' current state and (3) the output or success message.
         type: tuple
         items:
           read:
@@ -407,6 +392,9 @@ def read(
                   forwardv6:
                     description: content of net.ipv6.conf.all.forwarding sysctl in network name space
                     type: string
+          message:
+            description: a status or error message, depending on whether the operation succeeded or not.
+            type: string
     """
 
     # Default config_file if it is None
@@ -417,32 +405,46 @@ def read(
 
     messages = {
         1200: f'1200: Successfully retrieved network name space {name} status from both PodNet nodes.',
-        3221: f'3221: Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace_payload: ',
-        3222: f'3222: Failed to find name space {name} on the enabled PodNet. Payload exited with status ',
-        3223: f'3223: Failed to connect to the enabled PodNet from the config file {config_file} for find_forwardv4_payload',
-        3224: f'3224: Failed to run find_forwardv4_payload {name} on the enabled PodNet. Payload exited with status ',
-        3225: f'3225: Unexpected value for sysctl net.ipv4.ip_forward in name space {name} on the enabled PodNet ',
-        3226: f'3226: Failed to connect to the enabled PodNet from the config file {config_file} for find_forwardv6_payload: ',
-        3227: f'3227: Failed to run {name} find_forwardv4_payload on the enabled PodNet. Payload exited with status ',
-        3228: f'3228: Unexpected value for sysctl net.ipv6.conf.all.forwarding in name space {name} on the enabled PodNet ',
-        3231: f'3231: Failed to connect to the disabled PodNet from the config file {config_file} for find_namespace_payload: ',
-        3232: f'3232: Failed to find name space {name} on the disabled PodNet. Payload exited with status ',
-        3233: f'3233: Failed to connect to the disabled PodNet for find_forwardv4_payload.: ',
-        3234: f'3234: Failed to run find_forwardv4_payload on the disabled PodNet. Payload exited with status ',
-        3235: f'3235: Value for sysctl net.ipv4.ip_forward on disabled PodNet is unexpected ',
-        3236: f'3236: Failed to connect to the disabled PodNet from the config file {config_file} for find_forwardv6_payload: ',
-        3237: f'3237: Failed to run find_forwardv6_payload on disabled PodNet. Payload exited with status ',
-        3238: f'3238: Value for sysctl net.ipv6.conf.all.forwarding on disabled PodNet is unexpected ',
+        3221: f'Failed to connect to the enabled PodNet for find_namespace_payload: ',
+        3222: f'Failed to run find_namespace payload on the enabled PodNet. Payload exited with status ',
+        3223: f'Failed to connect to the enabled PodNet for find_forwardv4_payload',
+        3224: f'Failed to run find_forwardv4 payload on the enabled PodNet. Payload exited with status ',
+        3225: f'Unexpected value for sysctl net.ipv4.ip_forward in name space {name} on the enabled PodNet: ',
+        3226: f'Failed to connect to the enabled PodNet for find_forwardv6_payload: ',
+        3227: f'Failed to run find_forwardv6_payload on the enabled PodNet. Payload exited with status ',
+        3228: f'Unexpected value for sysctl net.ipv6.conf.all.forwarding on enabled PodNet: ',
+        3229: f'Failed to connect to the enabled PodNet for find_lo_status payload: ',
+        3230: f'Failed to run payload find_lo_status. Payload exited with status ',
+        3231: f'Failed to connect to the enabled PodNet for find_lo1 payload: ',
+        3232: f'Failed to run payload find_lo1. Payload exited with status ',
+        3233: f'Failed to connect to the enabled PodNet for find_lo1_status payload: ',
+        3234: f'Failed to run payload find_lo1_status. Payload exited with status ',
+        3235: f'Failed to connect to the enabled PodNet for find_lok_address payload: ',
+        3236: f'Failed to run payload find_lo1_address. Payload exited with status ',
+
+        3251: f'Failed to connect to the disabled PodNet for find_namespace_payload: ',
+        3252: f'Failed to find_namespace payload on the disabled PodNet. Payload exited with status ',
+        3253: f'Failed to connect to the disabled PodNet for find_forwardv4_payload.: ',
+        3254: f'Failed to run find_forwardv4_payload on the disabled PodNet. Payload exited with status ',
+        3255: f'Unexpected value for sysctl net.ipv4.ip_forward on disabled PodNet: ',
+        3256: f'Failed to connect to the disabled PodNet for find_forwardv6_payload: ',
+        3257: f'Failed to run find_forwardv6 payload on disabled PodNet. Payload exited with status ',
+        3258: f'Unexpected value for sysctl net.ipv6.conf.all.forwarding on disabled PodNet: ',
+        3259: f'Failed to connect to the enabled PodNet for find_lo_status payload: ',
+        3260: f'Failed to run payload find_lo_status. Payload exited with status ',
+        3261: f'Failed to connect to the enabled PodNet for find_lo1 payload: ',
+        3262: f'Failed to run payload find_lo1. Payload exited with status ',
+        3263: f'Failed to connect to the enabled PodNet for find_lo1_status payload: ',
+        3264: f'Failed to run payload find_lo1_status. Payload exited with status ',
+        3265: f'Failed to connect to the enabled PodNet for find_lok_address payload: ',
+        3266: f'Failed to run payload find_lo1_address. Payload exited with status ',
     }
 
-    retval = True
-    data_dict = None
-    message_list = ()
 
     status, config_data, msg = load_pod_config(config_file)
     if not status:
       if config_data['raw'] is None:
-          return False, msg
+          return False, None, msg
       else:
           return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
               indent=2,
@@ -451,120 +453,118 @@ def read(
     disabled = config_data['processed']['enabled']
 
     name_grepsafe = name.replace('.', '\.')
+    lo_addr_grepsafe = lo_addr.replace('.', '\.')
 
-    # define payloads
-    find_namespace_payload = "ip netns list | grep -w '{name_grepsafe}'"
-    find_forwardv4_payload = "ip netns exec {name} sysctl --write net.ipv4.ip_forward | awk '{print $3}"
-    find_forwardv6_payload = "ip netns exec {name} sysctl --write net.ipv6.conf.all.forwarding | awk {print $3}'"
+    def run_podnet(podnet_node, prefix, successful_payloads, data_dict):
+        retval = True
 
-    # call rcc comms_ssh for name space retrieval from enabled PodNet
-    ret = comms_ssh(
-        host_ip=enabled,
-        payload=find_namespace_payload,
-        username='robot',
-    )
+        rcc = CommsWrapper(comms_ssh, podnet_node, 'robot')
+        fmt = ErrorFormatter(
+            messages,
+            podnet_node,
+            podnet_node == enabled,
+            prefix,
+            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'}
+        )
 
-    if ret["channel_code"] != CHANNEL_SUCCESS:
-        retval = False
-        message_list.append(messages[3221] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}')
+        payloads = {
+            'find_namespace':     "ip netns list | grep -w '{name_grepsafe}'",
+            'find_forwardv4':     "ip netns exec {name} sysctl net.ipv4.ip_forward",
+            'find_forwardv6':     "ip netns exec {name} sysctl net.ipv6.conf.all.forwarding",
+            'find_lo_status':     "ip netns exec {name} ip link show lo | grep UP,LOWER_UP",
+            'find_lo1':           "ip netns exec {name} ip link show lo1",
+            'find_lo1_status':    "ip netns exec {name} ip link show lo | grep UP,LOWER_UP",
+            'find_lo1_address':   "ip netns exec {name} show dev lo1 | grep -w '{lo_addr_grepsafe}'",
+        }
 
-    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
-        retval = False
-        message_list.append(messages[3222] + f'{payload_code}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
-    else:
-        data_dict[enabled]['entry'] = ret["payload_message"]
-
-    # call rcc comms_ssh for IPv4 forwarding status retrieval from enabled PodNet
-    ret = comms_ssh(
-        host_ip=enabled,
-        payload=find_forwardv4_payload,
-        username='robot',
-    )
-    if ret["channel_code"] != CHANNEL_SUCCESS:
-        retval = False
-        message_list.append(messages[3223] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}')
-
-    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
-        retval = False
-        message_list.append(messages[3224] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
-    else:
-        if ret["payload_message"] != '1':
+        ret = rcc.run(payloads['find_namespace'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
             retval = False
-            message_list.append(messages[3225] + f'(is: {ret["payload_message"]}s, should be: `1`).')
-        data_dict[enabled]['forwardv4'] = ret["payload_message"]
-
-    # call rcc comms_ssh for IPv6 forwarding status retrieval from enabled PodNet
-    ret = comms_ssh(
-        host_ip=enabled,
-        payload=find_forwardv6_payload,
-        username='robot',
-    )
-    if ret["channel_code"] != CHANNEL_SUCCESS:
-        retval = False
-        message_list.append(messages[3226] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}')
-
-    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
-        retval = False
-        message_list.append(messages[3227] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
-    else:
-        if ret["payload_message"] != '1':
+            fmt.store_channel_error(ret, "{prefix+1} : " + messages[prefix+1])
+        if ret["payload_code"] != SUCCESS_CODE:
             retval = False
-            message_list.append(messages[3228] + f'(is: {ret["payload_message"]}s, should be: `1`).')
-        data_dict[enabled]['forwardv6'] = ret["payload_message"]
+            fmt.store_payload_error(ret, "{prefix+2} : " + messages[prefix+2])
+        else:
+            data_dict[podnet_node]['entry'] = ret["payload_message"]
+            fmt.add_successful('find_namespace')
 
-    # call rcc comms_ssh for name space retrieval from disabled PodNet
-    ret = comms_ssh(
-        host_ip=disabled,
-        payload=find_namespace_payload,
-        username='robot',
-    )
-    if ret["channel_code"] != CHANNEL_SUCCESS:
-        retval = False
-        message_list.append(messages[3231] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}')
-
-    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
-        retval = False
-        message_list.append(messages[3232] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
-    else:
-        data_dict[disabled]['entry'] = ret["payload_message"]
-
-    # call rcc comms_ssh for IPv4 forwarding status retrieval from disabled PodNet
-    ret = comms_ssh(
-        host_ip=disabled,
-        payload=find_forwardv4_payload,
-        username='robot',
-    )
-    if ret["channel_code"] != CHANNEL_SUCCESS:
-        retval = False
-        message_list.append(messages[3233] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}')
-
-    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
-        retval = False
-        message_list.append(messages[3234] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
-    else:
-        if ret["payload_message"] != '1':
+        ret = rcc.run(payloads['forwardv4'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
             retval = False
-            message_list.append(messages[3235] + f'(is: {ret["payload_message"]}s, should be: `1`).')
-        data_dict[disabled]['forwardv4'] = ret["payload_message"]
-
-    # call rcc comms_ssh for IPv6 forwarding status retrieval from disabled PodNet
-    ret = comms_ssh(
-        host_ip=disabled,
-        payload=find_forwardv6_payload,
-        username='robot',
-    )
-    if ret["channel_code"] != CHANNEL_SUCCESS:
-        retval = False
-        message_list.append(messages[3236] + f'channel_code: {ret["channel_code"]}s.\nchannel_message: {ret["channel_message"]}\nchannel_error: {ret["channel_error"]}')
-
-    if (ret["payload_code"] is not None) and (ret["payload_code"] != SUCCESS_CODE):
-        retval = False
-        message_list.append(messages[3237] + f'{ret["payload_code"]}s.\nSTDOUT: {ret["payload_message"]}\nSTDERR: {ret["payload_error"]}')
-    else:
-        if ret["payload_message"] != '1':
+            fmt.store_channel_error(ret, "{prefix+3} : " + messages[prefix+3])
+        if ret["payload_code"] != SUCCESS_CODE:
             retval = False
-            message_list.append(messages[3238] + f'(is: {ret["payload_message"]}s, should be: `1`).')
-        data_dict[disabled]['forwardv6'] = ret["payload_message"]
+            fmt.store_payload_error(ret, "{prefix+4}: " + messages[prefix+4])
+        else:
+            data_dict[podnet_node]['forwardv4'] = ret["payload_message"]
+            fmt.add_successful('forwardv4')
+            if ret["payload_message"] != "1":
+                retval = False
+                fmt.store_payload_error(ret, "{prefix+5}: " + messages[prefix+5])
 
-    message_list.append(messages[1200])
-    return retval, data_dict, message_list
+        ret = rcc.run(payloads['forwardv6'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            retval = False
+            fmt.store_channel_error(ret, "{prefix+6}: " + messages[prefix+6])
+        if ret["payload_code"] != SUCCESS_CODE:
+            retval = False
+            fmt.store_payload_error(ret, "{prefix+7}: " + messages[prefix+7])
+        else:
+            data_dict[podnet_node]['forwardv6'] = ret["payload_message"]
+            fmt.add_successful('forwardv6')
+            if ret["payload_message"] != "1":
+                retval = False
+                fmt.store_payload_error(ret, "{prefix+8}: " + messages[prefix+8])
+
+        ret = rcc.run(payloads['find_lo_status'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            retval = False
+            fmt.store_channel_error(ret, "{prefix+9}: " + messages[prefix+9])
+        if ret["payload_code"] != SUCCESS_CODE:
+            retval = False
+            fmt.store_payload_error(ret, "{prefix+10}: " + messages[prefix+10])
+        else:
+            fmt.add_successful('find_lo_status')
+            data_dict[podnet_node]['lo_status'] = ret["payload_message"]
+
+        ret = rcc.run(payloads['find_lo1'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            retval = False
+            fmt.store_channel_error(ret, "{prefix+11}: " + messages[prefix+11])
+        if ret["payload_code"] != SUCCESS_CODE:
+            retval = False
+            fmt.store_payload_error(ret, "{prefix+12}: " + messages[prefix+12])
+        else:
+            fmt.add_successful('find_lo1')
+            data_dict[podnet_node]['lo1_config'] = ret["payload_message"]
+
+        ret = rcc.run(payloads['find_lo1_status'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            retval = False
+            fmt.store_channel_error(ret, "{prefix+13}: " + messages[prefix+13])
+        if ret["payload_code"] != SUCCESS_CODE:
+            retval = False
+            fmt.store_payload_error(ret, "{prefix+14}: " + messages[prefix+14])
+        else:
+            fmt.add_successful('find_lo1_status')
+
+        ret = rcc.run(payloads['find_lo1_address'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            retval = False
+            fmt.store_channel_error(ret, "{prefix+15}: " + messages[prefix+15])
+        if ret["payload_code"] != SUCCESS_CODE:
+            retval = False
+            fmt.store_payload_error(ret, "{prefix+16}: " + messages[prefix+16])
+        else:
+            fmt.add_successful('find_lo1_address')
+
+        return retval, fmt.message_list, fmt.successful_payloads
+
+    retval_a, msg_list, successful_payloads, data_dict = run_podnet(enabled, 3220, {}, {})
+
+    retval_b, msg_list, successful_payloads, data_dict = run_podnet(disabled, 3250, successful_payloads, data_dict)
+
+    if not (retval_a and retval_b):
+        return (retval_a and retval_b), data_dict, msg_list
+    else:
+       return True, data_dict, (messages[1100])

--- a/ns.py
+++ b/ns.py
@@ -1,0 +1,516 @@
+"""
+Primitive to Build, Read and Scrub a network name space on PodNet HA
+"""
+
+# stdlib
+import json
+import ipaddress
+from pathlib import Path
+from typing import Tuple
+# lib
+from cloudcix.rcc import comms_ssh, CouldNotConnectException
+# local
+
+
+__all__ = [
+    'build',
+    'scrub',
+    'read',
+]
+
+SUCCESS_CODE = 0
+
+
+def build(
+        name: str,
+        config_file=None,
+) -> Tuple[bool, str]:
+    """
+    description:
+        Creates a network name space on PodNet HA.
+
+    parameters:
+        name:
+            description: network namespace's name
+            type: string
+            required: true
+        config_file:
+            description: |
+                path to the config.json file. Defaults to /opt/robot/config.json if
+                not supplied.
+            type: string
+            required: false
+    return:
+        description: |
+            A tuple with a boolean flag stating if the build was successful or not and
+            the output or error message.
+        type: tuple
+    """
+    # Define message
+    messages = {
+        1000: f'1000: Successfully created network name space {name} on both PodNet nodes.',
+        1001: f'1001: Success: name space {name} exists already',
+        2111: f'2011: Config file {config_file} loaded.',
+        3011: f'3011: Failed to load config file {config_file}, It does not exist.',
+        3012: f'3012: Failed to get `ipv6_subnet` from config file {config_file}',
+        3013: f'3013: Invalid value for `ipv6_subnet` from config file {config_file}',
+        3014: f'3014: Failed to get `podnet_a_enabled` from config file {config_file}',
+        3015: f'3015: Failed to get `podnet_b_enabled` from config file {config_file}',
+        3016: f'3016: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
+        3017: f'3017: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
+        3018: f'3018: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
+        3021: f'3021: Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace_payload',
+        3022: f'3022: Failed to connect to the enabled PodNet from the config file {config_file} for create_namespace_payload',
+        3023: f'3023: Failed to create name space {name} on the enabled PodNet. Payload exited with status ',
+        3031: f'3031: Successfully created name space {namespace} on enabled PodNet but failed to connect to the disabled PodNet '
+              f'from the config file {config_file} for find_namespace_payload',
+        3032: f'3032: Successfully created name space {namespace} on enabled PodNet but failed to connect to the disabled PodNet '
+              f'from the config file {config_file} for create_namespace_payload',
+        3033: f'3033: Successfully created name space {namespace} on enabled PodNet but failed to create on the disabled PodNet. '
+               'Payload exited with status ',
+    }
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/opt/robot/config.json'
+
+    # Get load config from config_file
+    if not Path(config_file).exists():
+        return False, messages[3011]
+    with Path(config_file).open('r') as file:
+        config = json.load(file)
+
+    # Get the ipv6_subnet from config_file
+    ipv6_subnet = config.get('ipv6_subnet', None)
+    if ipv6_subnet is None:
+        return False, messages[3012]
+    # Verify the ipv6_subnet value
+    try:
+        ipaddress.ip_network(ipv6_subnet)
+    except ValueError:
+        return False, messages[3013]
+
+    # Get the PodNet Mgmt ips from ipv6_subnet
+    podnet_a = f'{ipv6_subnet.split("/")[0]}10:0:2'
+    podnet_b = f'{ipv6_subnet.split("/")[0]}10:0:3'
+
+    # Get `podnet_a_enabled` and `podnet_b_enabled`
+    podnet_a_enabled = config.get('podnet_a_enabled', None)
+    if podnet_a_enabled is None:
+        return False, messages[3014]
+    podnet_b_enabled = config.get('podnet_b_enabled', None)
+    if podnet_a_enabled is None:
+        return False, messages[3015]
+
+    # First run on enabled PodNet
+    if podnet_a_enabled is True and podnet_b_enabled is False:
+        enabled = podnet_a
+        disabled = podnet_b
+    elif podnet_a_enabled is False and podnet_b_enabled is True:
+        enabled = podnet_b
+        disabled = podnet_a
+    elif podnet_a_enabled is True and podnet_b_enabled is True:
+        return False, messages[3016]
+    elif podnet_a_enabled is False and podnet_b_enabled is False:
+        return False, messages[3017]
+    else:
+        return False, messages[3018]
+
+    name_grepsafe = name.replace('.', '\.')
+
+    # define payloads
+    find_namespace_payload = "ip netns list | grep -w '{name_grepsafe}'"
+    create_namespace_payload = "ip netns create {name}"
+
+    # call rcc comms_ssh on enabled PodNet
+    try:
+        exit_code, stdout, stderr = comms_ssh(
+            host_ip=enabled,
+            payload=find_namespace_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3021]
+
+    create_namespace = True
+    if exit_code == SUCCESS_CODE:
+        # No need to create this name space if it exists already
+        create_namespace = False
+
+    if create_namespace:
+      # call rcc comms_ssh on enabled PodNet
+      try:
+          exit_code, stdout, stderr = comms_ssh(
+              host_ip=enabled,
+              payload=create_namespace_payload,
+              username='robot',
+          )
+      except CouldNotConnectException:
+          return False, messages[3022]
+      if exit_code != SUCCESS_CODE:
+          return False, messages[3023]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+
+    # call rcc comms_ssh on disabled PodNet
+    try:
+        exit_code, stdout, stderr = comms_ssh(
+            host_ip=disabled,
+            payload=find_namespace_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3031]
+
+    create_namespace = True
+    if exit_code == SUCCESS_CODE:
+        # No need to create this name space if it exists already
+        create_namespace = False
+
+    if create_namespace:
+      # call rcc comms_ssh on disabled PodNet
+      try:
+          exit_code, stdout, stderr = comms_ssh(
+              host_ip=disabled,
+              payload=create_namespace_payload,
+              username='robot',
+          )
+      except CouldNotConnectException:
+          return False, messages[3032]
+      if exit_code != SUCCESS_CODE:
+          return False, messages[3033]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+
+    return True, messages[1000]
+
+
+def scrub(
+        domain_path: str,
+) -> Tuple[bool, str]:
+    """
+    description:
+        Removes a network name space from PodNet HA.
+
+    parameters:
+        name:
+            type: string
+            required: true
+        config_file:
+            description: path to the config.json file
+            type: string
+            required: false
+    return:
+        description: |
+            A tuple with a boolean flag stating if the scrub was successful or not and
+            the output or error message.
+        type: tuple
+    """
+    # Define message
+    messages = {
+        1100: f'1100: Successfully removed name space {name} from both PodNet nodes.',
+        2111: f'2111: Config file {config_file} loaded.',
+        3111: f'3111: Failed to load config file {config_file}, It does not exist.',
+        3112: f'3112: Failed to get `ipv6_subnet` from config file {config_file}',
+        3113: f'3113: Invalid value for `ipv6_subnet` from config file {config_file}',
+        3114: f'3114: Failed to get `podnet_a_enabled` from config file {config_file}',
+        3115: f'3115: Failed to get `podnet_b_enabled` from config file {config_file}',
+        3116: f'3116: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
+        3117: f'3117: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
+        3118: f'3118: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
+        3121: f'3121: Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace_payload',
+        3122: f'3122: Failed to connect to the enabled PodNet from the config file {config_file} for delete_namespace_payload',
+        3123: f'3123: Failed to delete name space {name} on the enabled PodNet. Payload exited with status ',
+        3131: f'3131: Successfully deleted name space {namespace} on enabled PodNet but failed to connect to the disabled PodNet '
+              f'from the config file {config_file} for find_namespace_payload',
+        3132: f'3132: Successfully deleted name space {namespace} on enabled PodNet but failed to connect to the disabled PodNet '
+              f'from the config file {config_file} for delete_namespace_payload',
+        3133: f'3133: Successfully deleted name space {namespace} on enabled PodNet but failed to delete on the disabled PodNet. '
+               'Payload exited with status ',
+    }
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/opt/robot/config.json'
+
+    # Get load config from config_file
+    if not Path(config_file).exists():
+        return False, messages[3111]
+    with Path(config_file).open('r') as file:
+        config = json.load(file)
+
+    # Get the ipv6_subnet from config_file
+    ipv6_subnet = config.get('ipv6_subnet', None)
+    if ipv6_subnet is None:
+        return False, messages[3112]
+    # Verify the ipv6_subnet value
+    try:
+        ipaddress.ip_network(ipv6_subnet)
+    except ValueError:
+        return False, messages[3113]
+
+    # Get the PodNet Mgmt ips from ipv6_subnet
+    podnet_a = f'{ipv6_subnet.split("/")[0]}10:0:2'
+    podnet_b = f'{ipv6_subnet.split("/")[0]}10:0:3'
+
+    # Get `podnet_a_enabled` and `podnet_b_enabled`
+    podnet_a_enabled = config.get('podnet_a_enabled', None)
+    if podnet_a_enabled is None:
+        return False, messages[3114]
+    podnet_b_enabled = config.get('podnet_b_enabled', None)
+    if podnet_a_enabled is None:
+        return False, messages[3115]
+
+    # First run on enabled PodNet
+    if podnet_a_enabled is True and podnet_b_enabled is False:
+        enabled = podnet_a
+        disabled = podnet_b
+    elif podnet_a_enabled is False and podnet_b_enabled is True:
+        enabled = podnet_b
+        disabled = podnet_a
+    elif podnet_a_enabled is True and podnet_b_enabled is True:
+        return False, messages[3116]
+    elif podnet_a_enabled is False and podnet_b_enabled is False:
+        return False, messages[3117]
+    else:
+        return False, messages[3118]
+
+    name_grepsafe = name.replace('.', '\.')
+
+    # define payloads
+    find_namespace_payload = "ip netns list | grep -w '{name_grepsafe}'"
+    delete_namespace_payload = "ip netns delete {name}"
+
+    # call rcc comms_ssh on enabled PodNet
+    try:
+        exit_code, stdout, stderr = comms_ssh(
+            host_ip=enabled,
+            payload=find_namespace_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3121]
+
+    delete_namespace = False
+    if exit_code == SUCCESS_CODE:
+        # No need to delete this name space if it exists already
+        delete_namespace = True
+
+    if delete_namespace:
+      # call rcc comms_ssh on enabled PodNet
+      try:
+          exit_code, stdout, stderr = comms_ssh(
+              host_ip=enabled,
+              payload=delete_namespace_payload,
+              username='robot',
+          )
+      except CouldNotConnectException:
+          return False, messages[3122]
+      if exit_code != SUCCESS_CODE:
+          return False, messages[3123]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+
+    # call rcc comms_ssh on disabled PodNet
+    try:
+        exit_code, stdout, stderr = comms_ssh(
+            host_ip=disabled,
+            payload=find_namespace_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        return False, messages[3131]
+
+    delete_namespace = False
+    if exit_code == SUCCESS_CODE:
+        # No need to delete this name space if it exists already
+        delete_namespace = True
+
+    if delete_namespace:
+      # call rcc comms_ssh on disabled PodNet
+      try:
+          exit_code, stdout, stderr = comms_ssh(
+              host_ip=disabled,
+              payload=delete_namespace_payload,
+              username='robot',
+          )
+      except CouldNotConnectException:
+          return False, messages[3132]
+      if exit_code != SUCCESS_CODE:
+          return False, messages[3133]  + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}'
+
+    return True, messages[1000]
+
+
+def read(
+        domain_path: str,
+) -> Tuple[bool, dict, str]:
+    """
+    description:
+        Reads cloud-init user data and meta data files for a virtual machine on
+        PodNet HA (if any) and returns them.
+
+    parameters:
+        domain_path:
+            description: path to the virtual machine's cloud-init directory.
+                         This must be the full path, up to and including the
+                         version component.
+            type: string
+            required: true
+        config_file:
+            description: path to the config.json file
+            type: string
+            required: false
+    return:
+        description: |
+            A list with 3 items: (1) a boolean status flag indicating if the
+            read was successfull, (2) a dict containing the data as read from
+            the both machines' current state and (3) the output or success message.
+        type: tuple
+        items:
+          read:
+            description: True if all read operations were successful, False otherwise.
+            type: boolean
+          data:
+            type: object
+            description: |
+              file contents retrieved from both podnet nodes. May be None if nothing
+              could be retrieved.
+            properties:
+              <podnet_ip>:
+                description: dict structure holding user data from machine <podnet_ip>
+                  type: object
+                  entry:
+                    description: |
+                        the entry of the network name space in the list output by
+                        `ip netns list`.
+                    type: string
+    """
+
+    # Define message
+    messages = {
+        1200: f'1200: Successfully retrieved network name space {name} status from both PodNet nodes.',
+        2211: f'2211: Config file {config_file} loaded.',
+        3211: f'3211: Failed to load config file {config_file}, It does not exist.',
+        3212: f'3212: Failed to get `ipv6_subnet` from config file {config_file}',
+        3213: f'3213: Invalid value for `ipv6_subnet` from config file {config_file}',
+        3214: f'3214: Failed to get `podnet_a_enabled` from config file {config_file}',
+        3215: f'3215: Failed to get `podnet_b_enabled` from config file {config_file}',
+        3216: f'3216: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
+        3217: f'3217: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
+        3218: f'3218: Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
+        3221: f'3221: Failed to connect to the enabled PodNet from the config file {config_file} for find_namespace payload',
+        3222: f'3222: Failed to find name space {name} on the enabled PodNet. Payload exited with status ',
+        3231: f'3231: Found name space {name} on enabled PodNet but failed to connect to the disabled PodNet '
+              f'from the config file {config_file} for find_namespace_payload',
+        3232: f'3232: Found name space {name} on enabled PodNet but failed to find it on the disabled PodNet. '
+               'Payload exited with status ',
+    }
+
+    retval = True
+    data_dict = None
+    message_list = ()
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/opt/robot/config.json'
+
+    # Get load config from config_file
+    if not Path(config_file).exists():
+        retval = False
+        message_list.append(messages[3211])
+    with Path(config_file).open('r') as file:
+        config = json.load(file)
+
+    # Get the ipv6_subnet from config_file
+    ipv6_subnet = config.get('ipv6_subnet', None)
+    if ipv6_subnet is None:
+        retval = False
+        message_list.append(messages[3212])
+    # Verify the ipv6_subnet value
+    try:
+        ipaddress.ip_network(ipv6_subnet)
+    except ValueError:
+        retval = False
+        message_list.append(messages[3213])
+
+    # Get the PodNet Mgmt ips from ipv6_subnet
+    podnet_a = f'{ipv6_subnet.split("/")[0]}10:0:2'
+    podnet_b = f'{ipv6_subnet.split("/")[0]}10:0:3'
+
+    data_dict = {}
+
+    data_dict[podnet_a] = {
+        'entry': None,
+    }
+
+    data_dict[podnet_b] = {
+        'entry': None,
+    }
+
+    # Get `podnet_a_enabled` and `podnet_b_enabled`
+    podnet_a_enabled = config.get('podnet_a_enabled', None)
+    if podnet_a_enabled is None:
+        retval = False
+        message_list.append(messages[3214])
+    podnet_b_enabled = config.get('podnet_b_enabled', None)
+    if podnet_a_enabled is None:
+        retval = False
+        message_list.append(messages[3215])
+
+    # First run on enabled PodNet
+    if podnet_a_enabled is True and podnet_b_enabled is False:
+        enabled = podnet_a
+        disabled = podnet_b
+    elif podnet_a_enabled is False and podnet_b_enabled is True:
+        enabled = podnet_b
+        disabled = podnet_a
+    elif podnet_a_enabled is True and podnet_b_enabled is True:
+        retval = False
+        message_list.append(messages[3216])
+    elif podnet_a_enabled is False and podnet_b_enabled is False:
+        retval = False
+        message_list.append(messages[3217])
+    else:
+        message_list.append(messages[3218])
+
+    if retval == False:
+        return retval, data_dict, message_list
+
+    name_grepsafe = name.replace('.', '\.')
+
+    # define payloads
+    find_namespace_payload = "ip netns list | grep -w '{name_grepsafe}'"
+
+    # call rcc comms_ssh for name space retrieval from enabled PodNet
+    try:
+        exit_code, stdout, stderr = comms_ssh(
+            host_ip=enabled,
+            payload=find_namespace_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        retval = False
+        message_list.append(messages[3221])
+        exit_code = None    # Make sure this is defined
+
+    if (exit_code is not None) and (exit_code != SUCCESS_CODE):
+        retval = False
+        message_list.append(messages[3222] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
+    else:
+        data_dict[enabled]['entry'] = stdout
+
+    # call rcc comms_ssh for name space retrieval from disabled PodNet
+    try:
+        exit_code, stdout, stderr = comms_ssh(
+            host_ip=disabled,
+            payload=find_namespace_payload,
+            username='robot',
+        )
+    except CouldNotConnectException:
+        retval = False
+        message_list.append(messages[3231])
+        exit_code = None    # Make sure this is defined
+
+    if (exit_code is not None) and (exit_code != SUCCESS_CODE):
+        retval = False
+        message_list.append(messages[3232] + f'{exit_code}s.\nSTDOUT: {stdout}\nSTDERR: {stderr}')
+    else:
+        data_dict[disabled]['entry'] = stdout
+
+    message_list.append(messages[1200])
+    return retval, data_dict, message_list

--- a/utils.py
+++ b/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Tuple
 # libs
 from jinja2 import Environment, meta, FileSystemLoader, Template
 # local
-from .exceptions import (
+from exceptions import (
     CouldNotFindPodNets,
     InvalidPodNetPrivate,
     InvalidPodNetMgmt,
@@ -53,18 +53,87 @@ def check_template_data(template_data: Dict[str, Any], template: Template) -> Tu
     return success, err
 
 
-def load_pod_config(config_filepath: str) -> Dict[str, Any]:
+def load_pod_config(config_file=None, prefix=4000) -> Dict[str, Any]:
     """
-    Checks for pod config.json from supplied config_filepath or the current working directory and
-    Loads into a json object and return the object
+    Checks for pod config.json from supplied config_filepath or the current working directory, 
+    loads into a json object and returns the object
     :return data: object with podnet config
     """
-    file_path = Path(config_filepath)
-    if not file_path.exists():
-        raise FileNotFoundError
-    with file_path.open('r') as json_file:
-        return json.load(json_file)
 
+    messages = {
+      10: 'Config file {config_file} loaded.',
+      11: 'Failed to open {config_file}: ',
+      12: 'Failed to parse {config_file}: ',
+      13: 'Failed to get `ipv6_subnet from config_file.',
+      14: 'Invalid value for `ipv6_subnet` from config file {config_file}',
+      15: 'Failed to get `podnet_a_enabled` from config file {config_file}',
+      16: 'Failed to get `podnet_b_enabled` from config file {config_file}',
+      17: 'Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are True',
+      18: 'Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, both are False',
+      19: 'Invalid values for `podnet_a_enabled` and `podnet_b_enabled`, one or both are non booleans',
+    }
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/opt/robot/config.json'
+
+
+    config_data = {
+      'raw': None,
+      'processed': None
+    }
+
+    # Load config from config_file
+    try:
+        with Path(config_file).open('r') as file:
+            config['file'] = json.load(file)
+    except OSError as e:
+            return False, config_data, messages[prefix + 11] + e.__str__()
+    except Exception as e:
+            return False, config_data, messages[prefix + 12] + e.__str__()
+
+    config_data['raw'] = config
+
+    # Get the ipv6_subnet from config_file
+    ipv6_subnet = config.get('ipv6_subnet', None)
+    if ipv6_subnet is None:
+        return False, config_data, ("%d: " % prefix + 13) + messages[13]
+    # Verify the ipv6_subnet value
+    try:
+        ipaddress.ip_network(ipv6_subnet)
+    except ValueError:
+        return False, config_data, messages[14]
+
+    # Get the PodNet Mgmt ips from ipv6_subnet
+    config['processed']['podnet_a'] = f'{ipv6_subnet.split("/")[0]}10:0:2'
+    config['processed']['podnet_b'] = f'{ipv6_subnet.split("/")[0]}10:0:3'
+
+    # Get `podnet_a_enabled` and `podnet_b_enabled`
+    podnet_a_enabled = config.get('podnet_a_enabled', None)
+    if podnet_a_enabled is None:
+        return False, config_data, ("%d: " % prefix + 15) + messages[15]
+    podnet_b_enabled = config.get('podnet_b_enabled', None)
+    if podnet_a_enabled is None:
+        return False, config_data, ("%d: " % prefix + 16) + messages[16]
+
+    # Determine enabled and disabled PodNet
+    if podnet_a_enabled is True and podnet_b_enabled is False:
+        enabled = podnet_a
+        disabled = podnet_b
+    elif podnet_a_enabled is False and podnet_b_enabled is True:
+        enabled = podnet_b
+        disabled = podnet_a
+    elif podnet_a_enabled is True and podnet_b_enabled is True:
+        return False, config_data, ("%d: " % prefix + 17) + messages[17]
+    elif podnet_a_enabled is False and podnet_b_enabled is False:
+        return False, config_data, ("%d: " % prefix + 18) + messages[18]
+    else:
+        return False, config_data, ("%d: " % prefix + 19) + messages[19]
+
+    config_data['processed']['enabled'] = enabled
+    config_data['processed']['disabled'] = disabled
+
+    return True, config_data, ("%d: " % prefix + 10) + messages[10]
 
 def get_podnets(config_filepath):
     data = load_pod_config(config_filepath)


### PR DESCRIPTION
This is the first component primitive of what was formerly the ns primitive. Two things of note:

* I included enabling IPv4/IPv6 forwarding in this one. One could put it in route-ns, too but that one is going to be complex enough as it is, so I prefer having it here.
* I greatly shortened the messages in read(). We should do this for all primitives, since including the whole epic of what succeeded before only makes sense if we return upon failure.