### PR TITLE
Implement nat_firewall_ns primitive #60

### DIFF
--- a/cloudcix_primitives/nat_firewall_ns.py
+++ b/cloudcix_primitives/nat_firewall_ns.py
@@ -1,18 +1,282 @@
 # stdlib
+import json
 from typing import Tuple
 # lib
+from cloudcix.rcc import CHANNEL_SUCCESS, comms_ssh, CONNECTION_ERROR, VALIDATION_ERROR
 # local
+from cloudcix_primitives.utils import load_pod_config, PodnetErrorFormatter, SSHCommsWrapper
 
 
 __all__ = [
     'build',
     'read',
+    'scrub',
 ]
 
+SUCCESS_CODE = 0
 
-def build() -> Tuple[bool, str]:
-    return(False, 'Not Implemted')
+def build(
+        namespace: str,
+        one_to_one: dict,
+        ranges: list,
+        public_ip_ns: str,
+        config_file=None,
+) -> Tuple[bool, str]:
+    """
+    description:
+        Builds nftables tables, base chains, user chains, interface sets, jump
+        rules and default base chain rules required for a CloudCIX project.
+        Throughout the life time of a project, the base chains are never
+        modified by another primitive. The user chains are managed by user
+        chain primitives such as project_firewall_ns or nat_firewall_ns.
+
+    parameters:
+        namespace:
+            description: VRF network name space's identifier, such as 'VRF453
+            type: string
+            required: true
+        one_to_one:
+          description: List of 1:1 mapping dictonaries from private IP address to public IP addrress.
+          type: list
+          properties:
+            private:
+                description:
+                    The private IP address to map to a public IP address.
+            public:
+                description:
+                    The public IP address a private IP address is mapped to.
+          required: false
+        ranges:
+          description: flat list of IP addresses to map to the name space's public IP address.
+          type: list
+          required: false
+        public_ip_ns:
+          description: the name space's pulic IP address.
+          type: str
+          required: true
+        config_file:
+            description: path to the config.json file
+            type: string
+            required: false
+    return:
+        description: |
+            A tuple with a boolean flag stating if the build was successful or not and
+            the output or error message.
+        type: tuple
+    """
+
+    messages = {
+    1000: f'1000: Successfully created default firewall in project name space {namespace} on both PodNet nodes.',
+
+    3021: f'Failed to connect to the enabled PodNet for flush_postrouting payload: ',
+    3022: f'Failed to run flush_postrouting payload on the enabled PodNet. Payload exited with status ',
+    3023: f'Failed to connect to the enabled PodNet for flush_prerouting payload: ',
+    3024: f'Failed to run flush_prerouting payload on the enabled PodNet. Payload exited with status ',
+    3025: f'Failed to connect to the enabled PodNet for postrouting_11 payload (%(payload)s): ',
+    3026: f'Failed to run postrouting_11 payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3027: f'Failed to connect to the enabled PodNet for prerouting_11 payload (%(payload)s): ',
+    3028: f'Failed to run prerouting_11 payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3029: f'Failed to connect to the enabled PodNet for range payload (%(payload)s): ',
+    3030: f'Failed to run range payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+
+    3061: f'Failed to connect to the enabled PodNet for flush_postrouting payload: ',
+    3062: f'Failed to run flush_postrouting payload on the enabled PodNet. Payload exited with status ',
+    3063: f'Failed to connect to the enabled PodNet for flush_prerouting payload: ',
+    3064: f'Failed to run flush_prerouting payload on the enabled PodNet. Payload exited with status ',
+    3065: f'Failed to connect to the enabled PodNet for postrouting_11 payload (%(payload)s): ',
+    3066: f'Failed to run postrouting_11 payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3067: f'Failed to connect to the enabled PodNet for prerouting_11 payload (%(payload)s): ',
+    3068: f'Failed to run prerouting_11 payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3069: f'Failed to connect to the enabled PodNet for range payload (%(payload)s): ',
+    3070: f'Failed to run range payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    }
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/opt/robot/config.json'
+
+
+    status, config_data, msg = load_pod_config(config_file)
+    if not status:
+      if config_data['raw'] is None:
+          return False, msg
+      else:
+          return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
+              indent=2,
+              sort_keys=True)
+    enabled = config_data['processed']['enabled']
+    disabled = config_data['processed']['disabled']
+
+    def run_podnet(podnet_node, prefix, successful_payloads):
+        rcc = SSHCommsWrapper(comms_ssh, podnet_node, 'robot')
+        fmt = PodnetErrorFormatter(
+            config_file,
+            podnet_node,
+            podnet_node == enabled,
+            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'},
+            successful_payloads
+        )
+
+        payloads = {
+            'flush_postrouting': f'ip netns exec ns1100 nft flush inet NAT POSTROUTING',
+            'flush_prerouting': f'ip netns exec ns1100 nft flush inet NAT PREROUTING',
+        }
+
+
+        rule_templates = {
+          'prerouting_11': f'ip netns exec {namespace} '
+                           'nft add rule ip NAT POSTROUTING ip saddr %(private)s snat to %(public)s',
+          'postrouting_11': f'ip netns exec {namespace} '
+                            'nft add rule ip NAT PREROUTING ip saddr %(private)s snat to %(public)s',
+          'range': f'ip netns exec {namespace} '
+                   f'nft add rule ip NAT POSTROUTING ip saddr %(network)s snat to {public_ip_ns}'
+        }
+
+        ret = rcc.run(payloads['flush_postrouting'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+1}: " + messages[prefix+1]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+2}: " + messages[prefix+2]), fmt.successful_payloads
+        fmt.add_successful('flush_postrouting', ret)
+
+        ret = rcc.run(payloads['flush_prerouting'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+3}: " + messages[prefix+3]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+4}: " + messages[prefix+4]), fmt.successful_payloads
+        fmt.add_successful('flush_prerouting', ret)
+
+        for mapping in one_to_one:
+            payload_prerouting = rule_templates['prerouting_11'] % mapping
+            payload_postrouting = rule_templates['prerouting_11'] % mapping
+
+            ret = rcc.run(payload_postrouting)
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, f"{prefix+5}: " + messages[prefix+5] % {'payload': payload_postrouting}, fmt.successful_payloads)
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error(ret, f"{prefix+6}: " + messages[prefix+6] % {'payload': payload_postrouting}, fmt.successful_payloads)
+            fmt.add_successful('postrouting_11 (%s)' % payload_postrouting, ret)
+
+            ret = rcc.run(payload_prerouting)
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, f"{prefix+7}: " + messages[prefix+7] % {'payload': payload_prerouting}, fmt.successful_payloads)
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error(ret, f"{prefix+8}: " + messages[prefix+8] % {'payload': payload_prerouting}, fmt.successful_payloads)
+            fmt.add_successful('prerouting_11 (%s)' % payload_prerouting, ret)
+
+        for network in ranges:
+            payload = rule_templates['range'] % {'network': network}
+
+            ret = rcc.run(payload)
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, f"{prefix+9}: " + messages[prefix+9] % {'payload': payload}, fmt.successful_payloads)
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error(ret, f"{prefix+10}: " + messages[prefix+10] % {'payload': payload}, fmt.successful_payloads)
+            fmt.add_successful('range (%s)' % payload, ret)
+
+        return True, "", fmt.successful_payloads
+
+
+    status, msg, successful_payloads = run_podnet(enabled, 3020, {})
+    if status == False:
+        return status, msg
+
+    status, msg, successful_payloads = run_podnet(disabled, 3060, successful_payloads)
+    if status == False:
+        return status, msg
+
+    return True, messages[1000]
 
 
 def read() -> Tuple[bool, dict, str]:
-    return(False, {}, 'Not Implemted')
+    return(False, {}, 'Not Implemented')
+
+
+def scrub(
+    namespace: str,
+    config_file=None
+    ) -> Tuple[bool, str]:
+    """
+    description:
+        Builds nftables tables, base chains, user chains, interface sets, jump
+        rules and default base chain rules required for a CloudCIX project.
+        Throughout the life time of a project, the base chains are never
+        modified by another primitive. The user chains are managed by user
+        chain primitives such as project_firewall_ns or nat_firewall_ns.
+
+    parameters:
+        namespace:
+            description: VRF network name space's identifier, such as 'VRF453
+            type: string
+            required: true
+        public_bridge:
+          description: the name space's public bridge interface's name, such as 'br-B1'.
+          type: string
+          required: true
+        config_file:
+            description: path to the config.json file
+            type: string
+            required: false
+    return:
+        description: |
+            A tuple with a boolean flag stating if the build was successful or not and
+            the output or error message.
+        type: tuple
+    """
+
+    messages = {
+    1000: f'1000: Successfully scrubbed default firewall in project name space {namespace} on both PodNet nodes.',
+
+    3121: f'Failed to connect to the enabled PodNet for flush_ruleset payload: ',
+    3122: f'Failed to run flush_ruleset payload on the enabled PodNet. Payload exited with status ',
+    3161: f'Failed to connect to the disabled PodNet for flush_ruleset payload: ',
+    3162: f'Failed to run flush_ruleset payload on the disabled PodNet. Payload exited with status ',
+    }
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/opt/robot/config.json'
+
+    status, config_data, msg = load_pod_config(config_file)
+    if not status:
+      if config_data['raw'] is None:
+          return False, msg
+      else:
+          return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
+              indent=2,
+              sort_keys=True)
+    enabled = config_data['processed']['enabled']
+    disabled = config_data['processed']['disabled']
+
+    def run_podnet(podnet_node, prefix, successful_payloads):
+        rcc = SSHCommsWrapper(comms_ssh, podnet_node, 'robot')
+        fmt = PodnetErrorFormatter(
+            config_file,
+            podnet_node,
+            podnet_node == enabled,
+            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'},
+            successful_payloads
+        )
+
+        payloads = {
+            'flush_ruleset': f'ip netns exec {namespace} nft flush ruleset'
+        }
+
+        ret = rcc.run(payloads['flush_ruleset'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+1}: " + messages[prefix+1]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+2}: " + messages[prefix+2]), fmt.successful_payloads
+        fmt.add_successful('flush_ruleset', ret)
+        return True, "", fmt.successful_payloads
+
+
+    status, msg, successful_payloads = run_podnet(enabled, 3120, {})
+    if status == False:
+        return status, msg
+
+    status, msg, successful_payloads = run_podnet(disabled, 3160, successful_payloads)
+    if status == False:
+        return status, msg
+
+    return True, messages[1000]

--- a/cloudcix_primitives/nat_firewall_ns.py
+++ b/cloudcix_primitives/nat_firewall_ns.py
@@ -36,7 +36,7 @@ def build(
             type: string
             required: true
         one_to_one:
-          description: List of 1:1 mapping dictonaries from private IP address to public IP addrress.
+          description: List of 1:1 mapping dictonaries from private IP address to public IP address. May be empty.
           type: list
           properties:
             private:
@@ -45,11 +45,11 @@ def build(
             public:
                 description:
                     The public IP address a private IP address is mapped to.
-          required: false
-        ranges:
-          description: flat list of IP addresses to map to the name space's public IP address.
+          required: true
+        ranges
+          description: flat list of IP addresses to map to the name space's public IP address. May be empty.
           type: list
-          required: false
+          required: true
         public_ip_ns:
           description: the name space's pulic IP address.
           type: str

--- a/cloudcix_primitives/nat_firewall_ns.py
+++ b/cloudcix_primitives/nat_firewall_ns.py
@@ -18,7 +18,7 @@ SUCCESS_CODE = 0
 def build(
         namespace: str,
         one_to_one: List[Dict[str, str]],
-        ranges: list,
+        ranges: List[str],
         public_ip_ns: str,
         config_file=None,
 ) -> Tuple[bool, str]:

--- a/cloudcix_primitives/nat_firewall_ns.py
+++ b/cloudcix_primitives/nat_firewall_ns.py
@@ -17,7 +17,7 @@ SUCCESS_CODE = 0
 
 def build(
         namespace: str,
-        one_to_one: dict,
+        one_to_one: List[Dict[str, str]],
         ranges: list,
         public_ip_ns: str,
         config_file=None,

--- a/cloudcix_primitives/nat_firewall_ns.py
+++ b/cloudcix_primitives/nat_firewall_ns.py
@@ -24,11 +24,7 @@ def build(
 ) -> Tuple[bool, str]:
     """
     description:
-        Builds nftables tables, base chains, user chains, interface sets, jump
-        rules and default base chain rules required for a CloudCIX project.
-        Throughout the life time of a project, the base chains are never
-        modified by another primitive. The user chains are managed by user
-        chain primitives such as project_firewall_ns or nat_firewall_ns.
+        Creates 1:1 and network NAT rules in a name space.
 
     parameters:
         namespace:
@@ -66,7 +62,7 @@ def build(
     """
 
     messages = {
-    1000: f'1000: Successfully created default firewall in project name space {namespace} on both PodNet nodes.',
+    1000: f'1000: Successfully created NAT rules in project name space {namespace} on both PodNet nodes.',
 
     3021: f'Failed to connect to the enabled PodNet for flush_postrouting payload: ',
     3022: f'Failed to run flush_postrouting payload on the enabled PodNet. Payload exited with status ',
@@ -198,20 +194,31 @@ def scrub(
     ) -> Tuple[bool, str]:
     """
     description:
-        Builds nftables tables, base chains, user chains, interface sets, jump
-        rules and default base chain rules required for a CloudCIX project.
-        Throughout the life time of a project, the base chains are never
-        modified by another primitive. The user chains are managed by user
-        chain primitives such as project_firewall_ns or nat_firewall_ns.
+        Flushes all 1:1 and network NAT rules in a name space.
 
     parameters:
         namespace:
             description: VRF network name space's identifier, such as 'VRF453
             type: string
             required: true
-        public_bridge:
-          description: the name space's public bridge interface's name, such as 'br-B1'.
-          type: string
+        one_to_one:
+          description: List of 1:1 mapping dictonaries from private IP address to public IP address. May be empty.
+          type: list
+          properties:
+            private:
+                description:
+                    The private IP address to map to a public IP address.
+            public:
+                description:
+                    The public IP address a private IP address is mapped to.
+          required: true
+        ranges
+          description: flat list of IP addresses to map to the name space's public IP address. May be empty.
+          type: list
+          required: true
+        public_ip_ns:
+          description: the name space's pulic IP address.
+          type: str
           required: true
         config_file:
             description: path to the config.json file
@@ -225,17 +232,23 @@ def scrub(
     """
 
     messages = {
-    1000: f'1000: Successfully scrubbed default firewall in project name space {namespace} on both PodNet nodes.',
+    1000: f'1000: Successfully flushed NAT rules in project name space {namespace} on both PodNet nodes.',
 
-    3121: f'Failed to connect to the enabled PodNet for flush_ruleset payload: ',
-    3122: f'Failed to run flush_ruleset payload on the enabled PodNet. Payload exited with status ',
-    3161: f'Failed to connect to the disabled PodNet for flush_ruleset payload: ',
-    3162: f'Failed to run flush_ruleset payload on the disabled PodNet. Payload exited with status ',
+    3021: f'Failed to connect to the enabled PodNet for flush_postrouting payload: ',
+    3022: f'Failed to run flush_postrouting payload on the enabled PodNet. Payload exited with status ',
+    3023: f'Failed to connect to the enabled PodNet for flush_prerouting payload: ',
+    3024: f'Failed to run flush_prerouting payload on the enabled PodNet. Payload exited with status ',
+
+    3061: f'Failed to connect to the enabled PodNet for flush_postrouting payload: ',
+    3062: f'Failed to run flush_postrouting payload on the enabled PodNet. Payload exited with status ',
+    3063: f'Failed to connect to the enabled PodNet for flush_prerouting payload: ',
+    3064: f'Failed to run flush_prerouting payload on the enabled PodNet. Payload exited with status ',
     }
 
     # Default config_file if it is None
     if config_file is None:
         config_file = '/opt/robot/config.json'
+
 
     status, config_data, msg = load_pod_config(config_file)
     if not status:
@@ -259,23 +272,42 @@ def scrub(
         )
 
         payloads = {
-            'flush_ruleset': f'ip netns exec {namespace} nft flush ruleset'
+            'flush_postrouting': f'ip netns exec ns1100 nft flush inet NAT POSTROUTING',
+            'flush_prerouting': f'ip netns exec ns1100 nft flush inet NAT PREROUTING',
         }
 
-        ret = rcc.run(payloads['flush_ruleset'])
+
+        rule_templates = {
+          'prerouting_11': f'ip netns exec {namespace} '
+                           'nft add rule ip NAT POSTROUTING ip saddr %(private)s snat to %(public)s',
+          'postrouting_11': f'ip netns exec {namespace} '
+                            'nft add rule ip NAT PREROUTING ip saddr %(private)s snat to %(public)s',
+          'range': f'ip netns exec {namespace} '
+                   f'nft add rule ip NAT POSTROUTING ip saddr %(network)s snat to {public_ip_ns}'
+        }
+
+        ret = rcc.run(payloads['flush_postrouting'])
         if ret["channel_code"] != CHANNEL_SUCCESS:
             return False, fmt.channel_error(ret, f"{prefix+1}: " + messages[prefix+1]), fmt.successful_payloads
         if ret["payload_code"] != SUCCESS_CODE:
             return False, fmt.payload_error(ret, f"{prefix+2}: " + messages[prefix+2]), fmt.successful_payloads
-        fmt.add_successful('flush_ruleset', ret)
+        fmt.add_successful('flush_postrouting', ret)
+
+        ret = rcc.run(payloads['flush_prerouting'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+3}: " + messages[prefix+3]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+4}: " + messages[prefix+4]), fmt.successful_payloads
+        fmt.add_successful('flush_prerouting', ret)
+
         return True, "", fmt.successful_payloads
 
 
-    status, msg, successful_payloads = run_podnet(enabled, 3120, {})
+    status, msg, successful_payloads = run_podnet(enabled, 3020, {})
     if status == False:
         return status, msg
 
-    status, msg, successful_payloads = run_podnet(disabled, 3160, successful_payloads)
+    status, msg, successful_payloads = run_podnet(disabled, 3060, successful_payloads)
     if status == False:
         return status, msg
 

--- a/cloudcix_primitives/nat_firewall_ns.py
+++ b/cloudcix_primitives/nat_firewall_ns.py
@@ -1,6 +1,6 @@
 # stdlib
 import json
-from typing import Tuple
+from typing import Tuple, List, Dict
 # lib
 from cloudcix.rcc import CHANNEL_SUCCESS, comms_ssh, CONNECTION_ERROR, VALIDATION_ERROR
 # local
@@ -189,117 +189,5 @@ def read() -> Tuple[bool, dict, str]:
     return(False, {}, 'Not Implemented')
 
 
-def scrub(
-    namespace: str,
-    config_file=None
-    ) -> Tuple[bool, str]:
-    """
-    description:
-        Flushes all 1:1 and network NAT rules in a name space.
-
-    parameters:
-        namespace:
-            description: VRF network name space's identifier, such as 'VRF453
-            type: string
-            required: true
-        one_to_one:
-          description: List of 1:1 mapping dictonaries from private IP address to public IP address. May be empty.
-          type: list
-          properties:
-            private:
-                description:
-                    The private IP address to map to a public IP address.
-            public:
-                description:
-                    The public IP address a private IP address is mapped to.
-          required: true
-        ranges
-          description: flat list of IP addresses to map to the name space's public IP address. May be empty.
-          type: list
-          required: true
-        public_ip_ns:
-          description: the name space's pulic IP address.
-          type: str
-          required: true
-        config_file:
-            description: path to the config.json file
-            type: string
-            required: false
-    return:
-        description: |
-            A tuple with a boolean flag stating if the build was successful or not and
-            the output or error message.
-        type: tuple
-    """
-
-    messages = {
-    1000: f'1000: Successfully flushed NAT rules in project name space {namespace} on both PodNet nodes.',
-
-    3021: f'Failed to connect to the enabled PodNet for flush_postrouting payload: ',
-    3022: f'Failed to run flush_postrouting payload on the enabled PodNet. Payload exited with status ',
-    3023: f'Failed to connect to the enabled PodNet for flush_prerouting payload: ',
-    3024: f'Failed to run flush_prerouting payload on the enabled PodNet. Payload exited with status ',
-
-    3061: f'Failed to connect to the enabled PodNet for flush_postrouting payload: ',
-    3062: f'Failed to run flush_postrouting payload on the enabled PodNet. Payload exited with status ',
-    3063: f'Failed to connect to the enabled PodNet for flush_prerouting payload: ',
-    3064: f'Failed to run flush_prerouting payload on the enabled PodNet. Payload exited with status ',
-    }
-
-    # Default config_file if it is None
-    if config_file is None:
-        config_file = '/opt/robot/config.json'
-
-
-    status, config_data, msg = load_pod_config(config_file)
-    if not status:
-      if config_data['raw'] is None:
-          return False, msg
-      else:
-          return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
-              indent=2,
-              sort_keys=True)
-    enabled = config_data['processed']['enabled']
-    disabled = config_data['processed']['disabled']
-
-    def run_podnet(podnet_node, prefix, successful_payloads):
-        rcc = SSHCommsWrapper(comms_ssh, podnet_node, 'robot')
-        fmt = PodnetErrorFormatter(
-            config_file,
-            podnet_node,
-            podnet_node == enabled,
-            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'},
-            successful_payloads
-        )
-
-        payloads = {
-            'flush_postrouting': f'ip netns exec {namespace} nft flush chain NAT POSTROUTING',
-            'flush_prerouting': f'ip netns exec {namespace} nft flush chain NAT PREROUTING',
-        }
-
-        ret = rcc.run(payloads['flush_postrouting'])
-        if ret["channel_code"] != CHANNEL_SUCCESS:
-            return False, fmt.channel_error(ret, f"{prefix+1}: " + messages[prefix+1]), fmt.successful_payloads
-        if ret["payload_code"] != SUCCESS_CODE:
-            return False, fmt.payload_error(ret, f"{prefix+2}: " + messages[prefix+2]), fmt.successful_payloads
-        fmt.add_successful('flush_postrouting', ret)
-
-        ret = rcc.run(payloads['flush_prerouting'])
-        if ret["channel_code"] != CHANNEL_SUCCESS:
-            return False, fmt.channel_error(ret, f"{prefix+3}: " + messages[prefix+3]), fmt.successful_payloads
-        if ret["payload_code"] != SUCCESS_CODE:
-            return False, fmt.payload_error(ret, f"{prefix+4}: " + messages[prefix+4]), fmt.successful_payloads
-        fmt.add_successful('flush_prerouting', ret)
-
-        return True, "", fmt.successful_payloads
-
-
-    status, msg, successful_payloads = run_podnet(enabled, 3020, {})
-    if status == False:
-        return status, msg
-
-    status, msg, successful_payloads = run_podnet(disabled, 3060, successful_payloads)
-    if status == False:
-        return status, msg
-
-    return True, messages[1000]
+def scrub() -> Tuple[bool, str]:
+    return(False, {}, 'Not Implemented')

--- a/cloudcix_primitives/utils.py
+++ b/cloudcix_primitives/utils.py
@@ -161,10 +161,10 @@ def write_rule(namespace: str, rule: Dict[str, Optional[Any]], user_chain: str) 
     elif rule['protocol'] == 'icmp' and str(rule['version']) == '6':
         command.append('icmpv6 type { echo-request, mld-listener-query, nd-router-solicit, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert }')
     elif rule['protocol'] != 'any':
-        command.append(f'{rule['protocol']}')
+        command.append(rule["protocol"])
 
     if rule['port'] is not None:
-        command.append(f'dport {{ {rule['port']} }}')
+        command.append(f'dport {{ {rule["port"]} }}')
     
     if rule['log']:
         command.append(f'log prefix "Namespace_{namespace}_Table_FILTER" level debug')

--- a/tools/test_nat_firewall_ns.py
+++ b/tools/test_nat_firewall_ns.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+
+import sys
+import json
+from cloudcix_primitives import nat_firewall_ns
+
+# Prerequisites for running this test script:
+#
+#   tools/test_ns.py build ns1100
+#   tools/test_bridgeif_ns.py build br-B1 ns1100
+#   tools/test_default_firewall_ns.py build ns1100 br-B1
+
+# Fetch command and arguments
+cmd = sys.argv[1] if len(sys.argv) > 1 else None
+namespace_name = "ns1100"
+one_to_one = [
+        {'private': '10.0.0.10', 'public': '185.49.60.109'},
+        {'private': '10.0.0.20', 'public': '185.49.60.45'},
+    ]
+ranges = ['10.0.0.0/24', '172.16.10.0/24']
+public_ip_ns='185.49.60.108'
+
+config_file = "/etc/cloudcix/pod/configs/config.json"
+
+if len(sys.argv) > 2:
+    namespace_name = sys.argv[2]
+if len(sys.argv) > 3:
+    one_to_one = json.loads(sys.argv[3])
+if len(sys.argv) > 3:
+    ranges = json.loads(sys.argv[4])
+if len(sys.argv) > 4:
+    ranges = json.loads(sys.argv[5])
+
+
+status = None
+msg = None
+data = None
+
+# Check and execute command
+if cmd == 'build':
+    status, msg = nat_firewall_ns.build(namespace_name, one_to_one, ranges, public_ip_ns, config_file)
+elif cmd == 'read':
+    status, data, msg = nat_firewall_ns.read(namespace_name, config_file)
+elif cmd == 'scrub':
+    status, msg = nat_firewall_ns.scrub(namespace_name, config_file)
+else:
+   print(f"Unknown command: {cmd}")
+   sys.exit(1)
+
+
+# Output the status and messages
+print("Status: %s" % status)
+print("\nMessage:")
+if isinstance(msg, list):
+    for item in msg:
+        print(item)
+else:
+    print(msg)
+
+# Output data if available
+if data is not None:
+    print("\nData:")
+    print(json.dumps(data, sort_keys=True, indent=4))


### PR DESCRIPTION
This pull request implements the `nat_firewall_ns` primitive from #60. The code in this pull request has two dependencies:

* https://github.com/CloudCIX/primitives/pull/70 - without this it will choke on a syntax error in `cloudcix_primitives.utils.write_rule()'
* https://github.com/CloudCIX/primitives/pull/69 - needed to build the empty default firewall rule set this builds on.

Feel free to use my development branch for testing (it has all dependencies): https://github.com/jgrassler/primitives/tree/devel-nat-firewall-ns

Test results:

```
root@podnet-b:~# ip netns exec ns1100 nft list ruleset > ruleset.default_firewall_ns   # after running `tools/test_default_firewall_ns.py build ns1100 br-B1` and before running `tools/test_nat_firewall_ns.py build ns1100`
root@podnet-b:~# ip netns exec ns1100 nft list ruleset > ruleset.nat_firewall_ns  # after running ``tools/test_nat_firewall_ns.py build ns1100`
root@podnet-b:~# diff -u ruleset.default_firewall_ns ruleset.nat_firewall_ns 
--- ruleset.default_firewall_ns 2025-01-29 17:17:05.333300447 +0000
+++ ruleset.nat_firewall_ns     2025-01-29 17:17:39.395545344 +0000
@@ -1,10 +1,16 @@
 table ip NAT {
        chain POSTROUTING {
                type nat hook postrouting priority srcnat; policy accept;
+               ip saddr 10.0.0.10 snat to 185.49.60.109
+               ip saddr 10.0.0.20 snat to 185.49.60.45
+               ip saddr 10.0.0.0/24 snat to 185.49.60.108
+               ip saddr 172.16.10.0/24 snat to 185.49.60.108
        }
 
        chain PREROUTING {
                type nat hook prerouting priority dstnat; policy accept;
+               ip daddr 185.49.60.109 dnat to 10.0.0.10
+               ip daddr 185.49.60.45 dnat to 10.0.0.20
        }
 }
 table inet FILTER {
root@podnet-b:~#
```

