### PR TITLE
Implement project_firewall_ns primitive #61

### DIFF
--- a/cloudcix_primitives/project_firewall_ns.py
+++ b/cloudcix_primitives/project_firewall_ns.py
@@ -4,7 +4,7 @@ from typing import Tuple, List, Dict, Any
 # lib
 from cloudcix.rcc import CHANNEL_SUCCESS, comms_ssh, CONNECTION_ERROR, VALIDATION_ERROR
 # local
-from cloudcix_primitives.utils import load_pod_config, PodnetErrorFormatter, SSHCommsWrapper
+from cloudcix_primitives.utils import load_pod_config, PodnetErrorFormatter, SSHCommsWrapper, write_rule
 
 
 __all__ = [
@@ -121,20 +121,20 @@ def build(
     3021: f'Failed to connect to the enabled PodNet for flush_inbound payload: ',
     3022: f'Failed to run flush_inbound payload on the enabled PodNet. Payload exited with status ',
     3023: f'Failed to connect to the enabled PodNet for create_inbound_rule payload (%(payload)s): ',
-    3024: f'Failed to run flush_inbound payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3024: f'Failed to run create_inbound_rule payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
     3025: f'Failed to connect to the enabled PodNet for flush_outbound payload: ',
     3026: f'Failed to run flush_outbound payload on the enabled PodNet. Payload exited with status ',
     3027: f'Failed to connect to the enabled PodNet for create_outbound_rule payload (%(payload)s): ',
-    3028: f'Failed to run flush_outbound payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3028: f'Failed to run create_outbound_rule payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
 
     3061: f'Failed to connect to the disabled PodNet for flush_inbound payload: ',
     3062: f'Failed to run flush_inbound payload on the disabled PodNet. Payload exited with status ',
     3063: f'Failed to connect to the disabled PodNet for create_inbound_rule payload (%(payload)s): ',
-    3064: f'Failed to run flush_inbound payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    3064: f'Failed to run create_inbound_rule payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
     3065: f'Failed to connect to the disabled PodNet for flush_outbound payload: ',
     3066: f'Failed to run flush_outbound payload on the disabled PodNet. Payload exited with status ',
     3067: f'Failed to connect to the disabled PodNet for create_outbound_rule payload (%(payload)s): ',
-    3068: f'Failed to run flush_outbound payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    3068: f'Failed to run create_outbound_rule payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
     }
 
     # Default config_file if it is None

--- a/cloudcix_primitives/project_firewall_ns.py
+++ b/cloudcix_primitives/project_firewall_ns.py
@@ -126,6 +126,8 @@ def build(
     3026: f'Failed to run flush_outbound payload on the enabled PodNet. Payload exited with status ',
     3027: f'Failed to connect to the enabled PodNet for create_outbound_rule payload (%(payload)s): ',
     3028: f'Failed to run create_outbound_rule payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3029: f'Failed to connect to the enabled PodNet for add_final_accept payload (%(payload)s): ',
+    3030: f'Failed to run add_final_accept payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
 
     3061: f'Failed to connect to the disabled PodNet for flush_inbound payload: ',
     3062: f'Failed to run flush_inbound payload on the disabled PodNet. Payload exited with status ',
@@ -135,6 +137,8 @@ def build(
     3066: f'Failed to run flush_outbound payload on the disabled PodNet. Payload exited with status ',
     3067: f'Failed to connect to the disabled PodNet for create_outbound_rule payload (%(payload)s): ',
     3068: f'Failed to run create_outbound_rule payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    3069: f'Failed to connect to the disabled PodNet for add_final_accept payload (%(payload)s): ',
+    3070: f'Failed to run add_final_accept payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
     }
 
     # Default config_file if it is None
@@ -166,6 +170,7 @@ def build(
         payloads = {
             'flush_inbound': f'ip netns exec {namespace} nft flush chain inet FILTER PROJECT_IN',
             'flush_outbound': f'ip netns exec {namespace} nft flush chain inet FILTER PROJECT_OUT',
+            'add_final_accept': f'ip netns exec {namespace} nft add rule inet FILTER PROJECT_OUT accept',
         }
 
         ret = rcc.run(payloads['flush_inbound'])
@@ -201,6 +206,13 @@ def build(
            if ret["payload_code"] != SUCCESS_CODE:
                return False, fmt.payload_error(ret, f"{prefix+8}: " + messages[prefix+4] % {'payload': payload}), fmt.successful_payloads
            fmt.add_successful('create_outbound_rule (%s)' % payload, ret)
+
+        ret = rcc.run(payloads['add_final_accept'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+9}: " + messages[prefix+9]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+10}: " + messages[prefix+10]), fmt.successful_payloads
+        fmt.add_successful('add_final_accept', ret)
 
         return True, "", fmt.successful_payloads
 

--- a/cloudcix_primitives/project_firewall_ns.py
+++ b/cloudcix_primitives/project_firewall_ns.py
@@ -1,18 +1,224 @@
 # stdlib
-from typing import Tuple
+import json
+from typing import Tuple, List, Dict, Any
 # lib
+from cloudcix.rcc import CHANNEL_SUCCESS, comms_ssh, CONNECTION_ERROR, VALIDATION_ERROR
 # local
+from cloudcix_primitives.utils import load_pod_config, PodnetErrorFormatter, SSHCommsWrapper
 
 
 __all__ = [
     'build',
     'read',
+    'scrub',
 ]
 
+SUCCESS_CODE = 0
 
-def build() -> Tuple[bool, str]:
-    return(False, 'Not Implemted')
+def build(
+        namespace: str,
+        inbound: List[Dict[str, Any]],
+        outbound: List[Dict[str, Any]],
+        config_file=None,
+) -> Tuple[bool, str]:
+    """
+    description: |
+        Creates user defined rules in the PROJECT_IN and PROJECT_OUT user
+        chains in the FILTER tale of a project's network name space.
+
+    parameters:
+        namespace: |
+            description: VRF network name space's identifier, such as 'VRF453
+            type: string
+            required: true
+        inbound:
+          description: |
+              list of rule dictionaries for inbound rules to be created in
+              PROJECT_IN chain. These dictionaries will be processed by
+              cloudcix_primitives.utils.write_rule().
+          type: list
+          required: true
+          properties:
+            version:
+                type: int
+                description:
+                required: true
+                    IP version. Must be either 4 or 6.
+            source:
+                description:
+                type: string
+                required: true
+                    Source address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            destination:
+                description:
+                required: true
+                    Destination address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            protocol:
+                description: IP protocol, such as 'tcp', 'udp' or 'any'.
+            port:
+                description: port number
+                required: false
+            action:
+                description: |
+                    action to take if the rule matches. Can be 'accept', 'drop' or 'reject'.
+            log:
+                description: whether to log matches of the rule.
+                type: bool
+                required: true
+            order:
+                description: position of the rule in the chain.
+                type: int
+                required: true
+
+        outbound:
+          description: |
+              list of rule dictionaries for outbound rules to be created in
+              PROJECT_OUT chain. These dictionaries will be processed by
+              cloudcix_primitives.utils.write_rule().
+          type: list
+          required: true
+          properties:
+            version:
+                type: int
+                description:
+                required: true
+                    IP version. Must be either 4 or 6.
+            source:
+                description:
+                type: string
+                required: true
+                    Source address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            destination:
+                description:
+                required: true
+                    Destination address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            protocol:
+                description: IP protocol, such as 'tcp', 'udp' or 'any'.
+            port:
+                description: port number
+                required: false
+            action:
+                description: |
+                    action to take if the rule matches. Can be 'accept', 'drop' or 'reject'.
+            log:
+                description: whether to log matches of the rule.
+                type: bool
+                required: true
+            order:
+                description: position of the rule in the chain.
+                type: int
+                required: true
+    return:
+        description: |
+            A tuple with a boolean flag stating if the build was successful or not and
+            the output or error message.
+        type: tuple
+    """
+
+    messages = {
+    1000: f'1000: Successfully created inbound/outbound user rules in project name space {namespace} on both PodNet nodes.',
+
+    3021: f'Failed to connect to the enabled PodNet for flush_inbound payload: ',
+    3022: f'Failed to run flush_inbound payload on the enabled PodNet. Payload exited with status ',
+    3023: f'Failed to connect to the enabled PodNet for create_inbound_rule payload (%(payload)s): ',
+    3024: f'Failed to run flush_inbound payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3025: f'Failed to connect to the enabled PodNet for flush_outbound payload: ',
+    3026: f'Failed to run flush_outbound payload on the enabled PodNet. Payload exited with status ',
+    3027: f'Failed to connect to the enabled PodNet for create_outbound_rule payload (%(payload)s): ',
+    3028: f'Failed to run flush_outbound payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+
+    3061: f'Failed to connect to the disabled PodNet for flush_inbound payload: ',
+    3062: f'Failed to run flush_inbound payload on the disabled PodNet. Payload exited with status ',
+    3063: f'Failed to connect to the disabled PodNet for create_inbound_rule payload (%(payload)s): ',
+    3064: f'Failed to run flush_inbound payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    3065: f'Failed to connect to the disabled PodNet for flush_outbound payload: ',
+    3066: f'Failed to run flush_outbound payload on the disabled PodNet. Payload exited with status ',
+    3067: f'Failed to connect to the disabled PodNet for create_outbound_rule payload (%(payload)s): ',
+    3068: f'Failed to run flush_outbound payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    }
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/opt/robot/config.json'
+
+
+    status, config_data, msg = load_pod_config(config_file)
+    if not status:
+      if config_data['raw'] is None:
+          return False, msg
+      else:
+          return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
+              indent=2,
+              sort_keys=True)
+    enabled = config_data['processed']['enabled']
+    disabled = config_data['processed']['disabled']
+
+    def run_podnet(podnet_node, prefix, successful_payloads):
+        rcc = SSHCommsWrapper(comms_ssh, podnet_node, 'robot')
+        fmt = PodnetErrorFormatter(
+            config_file,
+            podnet_node,
+            podnet_node == enabled,
+            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'},
+            successful_payloads
+        )
+
+        payloads = {
+            'flush_inbound': f'ip netns exec {namespace} nft flush chain inet FILTER PROJECT_IN',
+            'flush_outbound': f'ip netns exec {namespace} nft flush chain inet FILTER PROJECT_OUT',
+        }
+
+        ret = rcc.run(payloads['flush_inbound'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+1}: " + messages[prefix+1]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+2}: " + messages[prefix+2]), fmt.successful_payloads
+        fmt.add_successful('flush_inbound', ret)
+
+        for rule in sorted(inbound, key=lambda fw: fw['order']):
+            payload = write_rule(namespace=namespace, rule=rule, user_chain='PROJECT_IN')
+
+            ret = rcc.run(payload)
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, f"{prefix+3}: " + messages[prefix+3] % {'payload': payload}), fmt.successful_payloads
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error(ret, f"{prefix+4}: " + messages[prefix+4] % {'payload': payload}), fmt.successful_payloads
+            fmt.add_successful('create_inbound_rule (%s)' % payload, ret)
+
+        ret = rcc.run(payloads['flush_outbound'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+5}: " + messages[prefix+3]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+6}: " + messages[prefix+4]), fmt.successful_payloads
+        fmt.add_successful('flush_outbound', ret)
+
+        for rule in sorted(outbound, key=lambda fw: fw['order']):
+           payload = write_rule(namespace=namespace, rule=rule, user_chain='PROJECT_OUT')
+
+           ret = rcc.run(payload)
+           if ret["channel_code"] != CHANNEL_SUCCESS:
+               return False, fmt.channel_error(ret, f"{prefix+7}: " + messages[prefix+3] % {'payload': payload}), fmt.successful_payloads
+           if ret["payload_code"] != SUCCESS_CODE:
+               return False, fmt.payload_error(ret, f"{prefix+8}: " + messages[prefix+4] % {'payload': payload}), fmt.successful_payloads
+           fmt.add_successful('create_outbound_rule (%s)' % payload, ret)
+
+        return True, "", fmt.successful_payloads
+
+
+    status, msg, successful_payloads = run_podnet(enabled, 3020, {})
+    if status == False:
+        return status, msg
+
+    status, msg, successful_payloads = run_podnet(disabled, 3060, successful_payloads)
+    if status == False:
+        return status, msg
+
+    return True, messages[1000]
 
 
 def read() -> Tuple[bool, dict, str]:
-    return(False, {}, 'Not Implemted')
+    return(False, {}, 'Not Implemented')
+
+
+def scrub() -> Tuple[bool, str]:
+    return(False, {}, 'Not Implemented')

--- a/tools/test_project_firewall_ns
+++ b/tools/test_project_firewall_ns
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+from cloudcix_primitives import project_firewall_ns
+
+# Prerequisites for running this test script:
+#
+#   tools/test_ns.py build ns1100
+#   tools/test_bridgeif_ns.py build br-B1 ns1100
+#   tools/test_default_firewall_ns.py build ns1100 br-B1
+
+# Fetch command and arguments
+cmd = sys.argv[1] if len(sys.argv) > 1 else None
+namespace_name = "ns1100"
+inbound=[
+    {
+        'version': 4,
+        'source': '0.0.0.0/0',
+        'destination': '10.0.0.2',
+        'protocol': 'tcp',
+        'port': '443, 80',
+        'action': 'accept',
+        'log': False,
+        'order': 0,
+    }, {
+        'version': 4,
+        'source': '2.3.4.5',
+        'destination': '10.0.0.2',
+        'protocol': 'tcp',
+        'port': '22',
+        'action': 'accept',
+        'log': False,
+        'order': 1,
+    }, {
+        'version': 6,
+        'source': '2:3:4::/64',
+        'destination': '5:6:7::/64',
+        'protocol': 'icmp',
+        'port': None,
+        'action': 'accept',
+        'log': False,
+        'order': 2,
+    }
+]
+
+outbound=[
+    {
+        'version': 4,  
+        'source': '10.0.0.2',
+        'destination': '1.2.3.0/24',
+        'protocol': 'any',
+        'port': 'any',
+        'action': 'drop',
+        'log': False,
+        'order': 0,
+    }, {
+        'version': 4,  
+        'source': '10.0.0.2',
+        'destination': '0.0.0.0/0',
+        'protocol': 'tcp',
+        'port': '22-25, 5509',
+        'action': 'drop',
+        'log': False,
+        'order': 1,
+    }, {
+        'version': 6,  
+        'source': '1:2:3::/64',
+        'destination': '5:6:7::/64',
+        'protocol': 'icmp',
+        'port': None,
+        'action': 'drop',
+        'log': False,
+        'order': 2,
+    },
+]
+
+config_file = "/etc/cloudcix/pod/configs/config.json"
+
+if len(sys.argv) > 2:
+    namespace_name = sys.argv[2]
+if len(sys.argv) > 3:
+    inbound = json.loads(sys.argv[3])
+if len(sys.argv) > 3:
+    outbound = json.loads(sys.argv[4])
+
+
+status = None
+msg = None
+data = None
+
+# Check and execute command
+if cmd == 'build':
+    status, msg = project_firewall_ns.build(namespace_name, inbound, outbound, config_file)
+elif cmd == 'read':
+    status, data, msg = project_firewall_ns.read(namespace_name, config_file)
+elif cmd == 'scrub':
+    status, msg = project_firewall_ns.scrub(namespace_name, config_file)
+else:
+   print(f"Unknown command: {cmd}")
+   sys.exit(1)
+
+
+# Output the status and messages
+print("Status: %s" % status)
+print("\nMessage:")
+if isinstance(msg, list):
+    for item in msg:
+        print(item)
+else:
+    print(msg)
+
+# Output data if available
+if data is not None:
+    print("\nData:")
+    print(json.dumps(data, sort_keys=True, indent=4))


### PR DESCRIPTION
This pull request implements the `project_firewall_ns` primitive from #61. I modified the test scenario slightly to use static IP addresses instead of the sets in the issue because we don't have a `set_firewall_ns` primitive, yet.

During testing I discovered two more problems in `utils.write_rule()`. I created a pull request with fixes here: https://github.com/CloudCIX/primitives/pull/72

Until that one lands, you can use https://github.com/jgrassler/primitives/tree/devel-project_firewall_ns for testing.

Rule set diff from testing:

```
root@podnet-b:~# diff -u ruleset.default_firewall_ns-pre_project_firewall_ns ruleset.project_firewall_ns 
--- ruleset.default_firewall_ns-pre_project_firewall_ns 2025-01-30 14:37:28.297907312 +0000
+++ ruleset.project_firewall_ns 2025-01-30 14:37:51.442744855 +0000
@@ -73,9 +73,15 @@
        }
 
        chain PROJECT_OUT {
+               ip saddr 10.0.0.2 ip daddr 1.2.3.0/24 drop
+               ip saddr 10.0.0.2 ip daddr 0.0.0.0/0 tcp dport { 22-25, 5509 } drop
+               ip6 saddr 1:2:3::/64 ip6 daddr 5:6:7::/64 icmpv6 type { echo-request, mld-listener-query, nd-router-solicit, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } drop
        }
 
        chain PROJECT_IN {
+               ip saddr 0.0.0.0/0 ip daddr 10.0.0.2 tcp dport { 80, 443 } accept
+               ip saddr 2.3.4.5 ip daddr 10.0.0.2 tcp dport 22 accept
+               ip6 saddr 2:3:4::/64 ip6 daddr 5:6:7::/64 icmpv6 type { echo-request, mld-listener-query, nd-router-solicit, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
        }
 
        chain VPNS2S {
root@podnet-b:~#
```