### PR TITLE
Implement vpns2s_firewall_ns primitive #62

### DIFF
--- a/cloudcix_primitives/vpns2s_firewall_ns.py
+++ b/cloudcix_primitives/vpns2s_firewall_ns.py
@@ -126,7 +126,7 @@ def build(
             return False, fmt.payload_error(ret, f"{prefix+2}: " + messages[prefix+2]), fmt.successful_payloads
         fmt.add_successful('flush_vpns2s', ret)
 
-        for rule in sorted(vpns2s, key=lambda fw: fw['order']):
+        for rule in sorted(rules, key=lambda fw: fw['order']):
             payload = write_rule(namespace=namespace, rule=rule, user_chain='VPNS2S')
 
             ret = rcc.run(payload)

--- a/cloudcix_primitives/vpns2s_firewall_ns.py
+++ b/cloudcix_primitives/vpns2s_firewall_ns.py
@@ -1,18 +1,158 @@
 # stdlib
-from typing import Tuple
+import json
+from typing import Tuple, List, Dict, Any
 # lib
+from cloudcix.rcc import CHANNEL_SUCCESS, comms_ssh, CONNECTION_ERROR, VALIDATION_ERROR
 # local
+from cloudcix_primitives.utils import load_pod_config, PodnetErrorFormatter, SSHCommsWrapper, write_rule
 
 
 __all__ = [
     'build',
     'read',
+    'scrub',
 ]
 
+SUCCESS_CODE = 0
 
-def build() -> Tuple[bool, str]:
-    return(False, 'Not Implemted')
+def build(
+        namespace: str,
+        rules: List[Dict[str, Any]],
+        config_file=None,
+) -> Tuple[bool, str]:
+    """
+    description: |
+        Creates user defined rules in the VPNS2S user chain in the FILTER table
+        of a project's network name space.
+
+    parameters:
+        namespace: |
+            description: VRF network name space's identifier, such as 'VRF453
+            type: string
+            required: true
+        rules:
+          description: |
+              list of rule dictionaries for rules to be created in the VPNS2S
+              chain. These dictionaries will be processed by
+              cloudcix_primitives.utils.write_rule().
+          type: list
+          required: true
+          properties:
+            version:
+                type: int
+                description:
+                required: true
+                    IP version. Must be either 4 or 6.
+            source:
+                description:
+                type: string
+                required: true
+                    Source address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            destination:
+                description:
+                required: true
+                    Destination address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            protocol:
+                description: IP protocol, such as 'tcp', 'udp' or 'any'.
+            port:
+                description: port number
+                required: false
+            action:
+                description: |
+                    action to take if the rule matches. Can be 'accept', 'drop' or 'reject'.
+            log:
+                description: whether to log matches of the rule.
+                type: bool
+                required: true
+            order:
+                description: position of the rule in the chain.
+                type: int
+                required: true
+    return:
+        description: |
+            A tuple with a boolean flag stating if the build was successful or not and
+            the output or error message.
+        type: tuple
+    """
+
+    messages = {
+    1000: f'1000: Successfully created VPNS2S user rules in project name space {namespace} on both PodNet nodes.',
+
+    3021: f'Failed to connect to the enabled PodNet for flush_vpns2s payload: ',
+    3022: f'Failed to run flush_vpns2s payload on the enabled PodNet. Payload exited with status ',
+    3023: f'Failed to connect to the enabled PodNet for create_vpns2s_rule payload (%(payload)s): ',
+    3024: f'Failed to run create_vpns2s_rule payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+
+    3061: f'Failed to connect to the enabled PodNet for flush_vpns2s payload: ',
+    3062: f'Failed to run flush_vpns2s payload on the enabled PodNet. Payload exited with status ',
+    3063: f'Failed to connect to the enabled PodNet for create_vpns2s_rule payload (%(payload)s): ',
+    3064: f'Failed to run create_vpns2s_rule payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    }
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/opt/robot/config.json'
+
+
+    status, config_data, msg = load_pod_config(config_file)
+    if not status:
+      if config_data['raw'] is None:
+          return False, msg
+      else:
+          return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
+              indent=2,
+              sort_keys=True)
+    enabled = config_data['processed']['enabled']
+    disabled = config_data['processed']['disabled']
+
+    def run_podnet(podnet_node, prefix, successful_payloads):
+        rcc = SSHCommsWrapper(comms_ssh, podnet_node, 'robot')
+        fmt = PodnetErrorFormatter(
+            config_file,
+            podnet_node,
+            podnet_node == enabled,
+            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'},
+            successful_payloads
+        )
+
+        payloads = {
+            'flush_vpns2s': f'ip netns exec {namespace} nft flush chain inet FILTER VPNS2S',
+        }
+
+        ret = rcc.run(payloads['flush_vpns2s'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+1}: " + messages[prefix+1]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+2}: " + messages[prefix+2]), fmt.successful_payloads
+        fmt.add_successful('flush_vpns2s', ret)
+
+        for rule in sorted(vpns2s, key=lambda fw: fw['order']):
+            payload = write_rule(namespace=namespace, rule=rule, user_chain='VPNS2S')
+
+            ret = rcc.run(payload)
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, f"{prefix+3}: " + messages[prefix+3] % {'payload': payload}), fmt.successful_payloads
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error(ret, f"{prefix+4}: " + messages[prefix+4] % {'payload': payload}), fmt.successful_payloads
+            fmt.add_successful('create_vpns2s_rule (%s)' % payload, ret)
+
+        return True, "", fmt.successful_payloads
+
+
+    status, msg, successful_payloads = run_podnet(enabled, 3020, {})
+    if status == False:
+        return status, msg
+
+    status, msg, successful_payloads = run_podnet(disabled, 3060, successful_payloads)
+    if status == False:
+        return status, msg
+
+    return True, messages[1000]
 
 
 def read() -> Tuple[bool, dict, str]:
-    return(False, {}, 'Not Implemted')
+    return(False, {}, 'Not Implemented')
+
+
+def scrub() -> Tuple[bool, str]:
+    return(False, {}, 'Not Implemented')

--- a/tools/test_vpns2s_firewall_ns.py
+++ b/tools/test_vpns2s_firewall_ns.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+from cloudcix_primitives import vpns2s_firewall_ns
+
+# Prerequisites for running this test script:
+#
+#   tools/test_ns.py build ns1100
+#   tools/test_bridgeif_ns.py build br-B1 ns1100
+#   tools/test_default_firewall_ns.py build ns1100 br-B1
+
+# Fetch command and arguments
+cmd = sys.argv[1] if len(sys.argv) > 1 else None
+namespace_name = "ns1100"
+rules=[
+    {
+        'version': 4,  
+        'source': '10.0.0.0/24',
+        'destination': '10.11.0.0/24',
+        'protocol': 'any',
+        'port': None,
+        'action': 'accept',
+        'log': False,
+        'order': 0,
+    }, {
+        'version': 4,  
+        'source': '10.11.0.0/24',
+        'destination': '10.0.0.0/24',
+        'protocol': 'any',
+        'port': None,
+        'action': 'accept',
+        'log': False,
+        'order': 1,
+    }, {
+        'version': 4,  
+        'source': '10.10.0.0/24',
+        'destination': '10.21.0.0/24',
+        'protocol': 'tcp',
+        'port': '5432',
+        'action': 'accept',
+        'log': False,
+        'order': 2,
+    },
+]
+
+config_file = "/etc/cloudcix/pod/configs/config.json"
+
+if len(sys.argv) > 2:
+    namespace_name = sys.argv[2]
+if len(sys.argv) > 3:
+    rules = json.loads(sys.argv[3])
+
+
+status = None
+msg = None
+data = None
+
+# Check and execute command
+if cmd == 'build':
+    status, msg = vpns2s_firewall_ns.build(namespace_name, rules, config_file)
+elif cmd == 'read':
+    status, data, msg = vpns2s_firewall_ns.read(namespace_name, config_file)
+elif cmd == 'scrub':
+    status, msg = vpns2s_firewall_ns.scrub(namespace_name, config_file)
+else:
+   print(f"Unknown command: {cmd}")
+   sys.exit(1)
+
+
+# Output the status and messages
+print("Status: %s" % status)
+print("\nMessage:")
+if isinstance(msg, list):
+    for item in msg:
+        print(item)
+else:
+    print(msg)
+
+# Output data if available
+if data is not None:
+    print("\nData:")
+    print(json.dumps(data, sort_keys=True, indent=4))


### PR DESCRIPTION
This pull request implements the vpns2s_firewall_ns primitive from #62. Just like https://github.com/CloudCIX/primitives/pull/73 this depends on https://github.com/CloudCIX/primitives/pull/72 to work. For testing I created a branch that includes these `utils.write_rule()` changes again: https://github.com/CloudCIX/primitives/pull/72

Diff from testing:

```
root@podnet-b:~# diff -u ruleset.default_firewall_ns-pre_vpns2s_firewall_ns ruleset.vpns2s_firewall_ns
--- ruleset.default_firewall_ns-pre_vpns2s_firewall_ns  2025-01-30 16:04:25.786640020 +0000
+++ ruleset.vpns2s_firewall_ns  2025-01-30 16:07:14.236727535 +0000
@@ -79,6 +79,9 @@
        }
 
        chain VPNS2S {
+               ip saddr 10.0.0.0/24 ip daddr 10.11.0.0/24 accept
+               ip saddr 10.11.0.0/24 ip daddr 10.0.0.0/24 accept
+               ip saddr 10.10.0.0/24 ip daddr 10.21.0.0/24 tcp dport 5432 accept
        }
 
        chain VPNDYN {
root@podnet-b:~#
```