### PR TITLE
Implement geo_a_firewall_ns primitive #63

### DIFF
--- a/cloudcix_primitives/geo_a_firewall_ns.py
+++ b/cloudcix_primitives/geo_a_firewall_ns.py
@@ -1,18 +1,250 @@
 # stdlib
-from typing import Tuple
+import json
+from typing import Tuple, List, Dict, Any
 # lib
+from cloudcix.rcc import CHANNEL_SUCCESS, comms_ssh, CONNECTION_ERROR, VALIDATION_ERROR
 # local
+from cloudcix_primitives.utils import load_pod_config, PodnetErrorFormatter, SSHCommsWrapper, write_rule
 
 
 __all__ = [
     'build',
     'read',
+    'scrub',
 ]
 
+SUCCESS_CODE = 0
 
-def build() -> Tuple[bool, str]:
-    return(False, 'Not Implemted')
+def build(
+        namespace: str,
+        inbound: List[Dict[str, Any]],
+        outbound: List[Dict[str, Any]],
+        config_file=None,
+) -> Tuple[bool, str]:
+    """
+    description: |
+        Creates user defined rules in the GEO_IN_ALLOW and GEO_OUT_ALLOW user
+        chains in the FILTER tale of a project's network name space.
+
+    parameters:
+        namespace: |
+            description: VRF network name space's identifier, such as 'VRF453
+            type: string
+            required: true
+        inbound:
+          description: |
+              list of rule dictionaries for inbound rules to be created in
+              GEO_IN_ALLOW chain. These dictionaries will be processed by
+              cloudcix_primitives.utils.write_rule().
+          type: list
+          required: true
+          properties:
+            version:
+                type: int
+                description:
+                required: true
+                    IP version. Must be either 4 or 6.
+            source:
+                description:
+                type: string
+                required: true
+                    Source address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            destination:
+                description:
+                required: true
+                    Destination address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            protocol:
+                description: IP protocol, such as 'tcp', 'udp' or 'any'.
+            port:
+                description: port number
+                required: false
+            action:
+                description: |
+                    action to take if the rule matches. Can be 'accept', 'drop' or 'reject'.
+            log:
+                description: whether to log matches of the rule.
+                type: bool
+                required: true
+            order:
+                description: position of the rule in the chain.
+                type: int
+                required: true
+
+        outbound:
+          description: |
+              list of rule dictionaries for outbound rules to be created in
+              GEO_OUT_ALLOW chain. These dictionaries will be processed by
+              cloudcix_primitives.utils.write_rule().
+          type: list
+          required: true
+          properties:
+            version:
+                type: int
+                description:
+                required: true
+                    IP version. Must be either 4 or 6.
+            source:
+                description:
+                type: string
+                required: true
+                    Source address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            destination:
+                description:
+                required: true
+                    Destination address with optional CIDR prefix length, e.g. 0.0.0.0/0
+            protocol:
+                description: IP protocol, such as 'tcp', 'udp' or 'any'.
+            port:
+                description: port number
+                required: false
+            action:
+                description: |
+                    action to take if the rule matches. Can be 'accept', 'drop' or 'reject'.
+            log:
+                description: whether to log matches of the rule.
+                type: bool
+                required: true
+            order:
+                description: position of the rule in the chain.
+                type: int
+                required: true
+    return:
+        description: |
+            A tuple with a boolean flag stating if the build was successful or not and
+            the output or error message.
+        type: tuple
+    """
+
+    messages = {
+    1000: f'1000: Successfully created inbound/outbound user rules in project name space {namespace} on both PodNet nodes.',
+
+    3021: f'Failed to connect to the enabled PodNet for flush_inbound payload: ',
+    3022: f'Failed to run flush_inbound payload on the enabled PodNet. Payload exited with status ',
+    3023: f'Failed to connect to the enabled PodNet for create_inbound_rule payload (%(payload)s): ',
+    3024: f'Failed to run create_inbound_rule payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3025: f'Failed to connect to the enabled PodNet for add_inbound_drop payload (%(payload)s): ',
+    3036: f'Failed to run add_inbound_drop payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3067: f'Failed to connect to the enabled PodNet for flush_outbound payload: ',
+    3028: f'Failed to run flush_outbound payload on the enabled PodNet. Payload exited with status ',
+    3029: f'Failed to connect to the enabled PodNet for create_outbound_rule payload (%(payload)s): ',
+    3030: f'Failed to run create_outbound_rule payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3031: f'Failed to connect to the enabled PodNet for add_outbound_drop payload (%(payload)s): ',
+    3032: f'Failed to run add_outbound_drop payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+
+    3061: f'Failed to connect to the disabled PodNet for flush_inbound payload: ',
+    3062: f'Failed to run flush_inbound payload on the disabled PodNet. Payload exited with status ',
+    3063: f'Failed to connect to the disabled PodNet for create_inbound_rule payload (%(payload)s): ',
+    3064: f'Failed to run create_inbound_rule payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    3065: f'Failed to connect to the disabled PodNet for add_inbound_drop payload (%(payload)s): ',
+    3036: f'Failed to run add_inbound_drop payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    3067: f'Failed to connect to the disabled PodNet for flush_outbound payload: ',
+    3068: f'Failed to run flush_outbound payload on the disabled PodNet. Payload exited with status ',
+    3069: f'Failed to connect to the disabled PodNet for create_outbound_rule payload (%(payload)s): ',
+    3070: f'Failed to run create_outbound_rule payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    3071: f'Failed to connect to the disabled PodNet for add_outbound_drop payload (%(payload)s): ',
+    3072: f'Failed to run add_outbound_drop payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    }
+
+    # Default config_file if it is None
+    if config_file is None:
+        config_file = '/opt/robot/config.json'
+
+
+    status, config_data, msg = load_pod_config(config_file)
+    if not status:
+      if config_data['raw'] is None:
+          return False, msg
+      else:
+          return False, msg + "\nJSON dump of raw configuration:\n" + json.dumps(config_data['raw'],
+              indent=2,
+              sort_keys=True)
+    enabled = config_data['processed']['enabled']
+    disabled = config_data['processed']['disabled']
+
+    def run_podnet(podnet_node, prefix, successful_payloads):
+        rcc = SSHCommsWrapper(comms_ssh, podnet_node, 'robot')
+        fmt = PodnetErrorFormatter(
+            config_file,
+            podnet_node,
+            podnet_node == enabled,
+            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'},
+            successful_payloads
+        )
+
+        payloads = {
+            'flush_inbound': f'ip netns exec {namespace} nft flush chain inet FILTER GEO_IN_ALLOW',
+            'add_inbound_drop': f'ip netns exec {namespace} nft add rule inet FILTER GEO_IN_ALLOW drop',
+            'flush_outbound': f'ip netns exec {namespace} nft flush chain inet FILTER GEO_OUT_ALLOW',
+            'add_outbound_drop': f'ip netns exec {namespace} nft add rule inet FILTER GEO_OUT_ALLOW drop',
+        }
+
+        ret = rcc.run(payloads['flush_inbound'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+1}: " + messages[prefix+1]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+2}: " + messages[prefix+2]), fmt.successful_payloads
+        fmt.add_successful('flush_inbound', ret)
+
+        for rule in sorted(inbound, key=lambda fw: fw['order']):
+            payload = write_rule(namespace=namespace, rule=rule, user_chain='PROJECT_IN')
+
+            ret = rcc.run(payload)
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, f"{prefix+3}: " + messages[prefix+3] % {'payload': payload}), fmt.successful_payloads
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error(ret, f"{prefix+4}: " + messages[prefix+4] % {'payload': payload}), fmt.successful_payloads
+            fmt.add_successful('create_inbound_rule (%s)' % payload, ret)
+
+        if (len(inbound) > 0):
+            ret = rcc.run(payloads['add_inbound_drop'])
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, f"{prefix+5}: " + messages[prefix+5]), fmt.successful_payloads
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error(ret, f"{prefix+6}: " + messages[prefix+6]), fmt.successful_payloads
+            fmt.add_successful('add_inbound_drop', ret)
+
+        ret = rcc.run(payloads['flush_outbound'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f"{prefix+7}: " + messages[prefix+7]), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f"{prefix+8}: " + messages[prefix+8]), fmt.successful_payloads
+        fmt.add_successful('flush_outbound', ret)
+
+        for rule in sorted(outbound, key=lambda fw: fw['order']):
+           payload = write_rule(namespace=namespace, rule=rule, user_chain='PROJECT_OUT')
+
+           ret = rcc.run(payload)
+           if ret["channel_code"] != CHANNEL_SUCCESS:
+               return False, fmt.channel_error(ret, f"{prefix+9}: " + messages[prefix+9] % {'payload': payload}), fmt.successful_payloads
+           if ret["payload_code"] != SUCCESS_CODE:
+               return False, fmt.payload_error(ret, f"{prefix+10}: " + messages[prefix+10] % {'payload': payload}), fmt.successful_payloads
+           fmt.add_successful('create_outbound_rule (%s)' % payload, ret)
+
+        if (len(outbound) > 0):
+            ret = rcc.run(payloads['add_outbound_drop'])
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, f"{prefix+11}: " + messages[prefix+11]), fmt.successful_payloads
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error(ret, f"{prefix+12}: " + messages[prefix+12]), fmt.successful_payloads
+            fmt.add_successful('add_outbound_drop', ret)
+
+        return True, "", fmt.successful_payloads
+
+
+    status, msg, successful_payloads = run_podnet(enabled, 3020, {})
+    if status == False:
+        return status, msg
+
+    status, msg, successful_payloads = run_podnet(disabled, 3060, successful_payloads)
+    if status == False:
+        return status, msg
+
+    return True, messages[1000]
 
 
 def read() -> Tuple[bool, dict, str]:
-    return(False, {}, 'Not Implemted')
+    return(False, {}, 'Not Implemented')
+
+
+def scrub() -> Tuple[bool, str]:
+    return(False, {}, 'Not Implemented')

--- a/cloudcix_primitives/geo_a_firewall_ns.py
+++ b/cloudcix_primitives/geo_a_firewall_ns.py
@@ -17,8 +17,8 @@ SUCCESS_CODE = 0
 
 def build(
         namespace: str,
-        inbound: List[Dict[str, Any]],
-        outbound: List[Dict[str, Any]],
+        inbound: List[str],
+        outbound: List[str],
         config_file=None,
 ) -> Tuple[bool, str]:
     """
@@ -33,81 +33,17 @@ def build(
             required: true
         inbound:
           description: |
-              list of rule dictionaries for inbound rules to be created in
-              GEO_IN_ALLOW chain. These dictionaries will be processed by
-              cloudcix_primitives.utils.write_rule().
+              list of GeoIP address sets to allow as destinations for outbund
+              traffic. All sets listed must exist. Can be empty.
           type: list
           required: true
-          properties:
-            version:
-                type: int
-                description:
-                required: true
-                    IP version. Must be either 4 or 6.
-            source:
-                description:
-                type: string
-                required: true
-                    Source address with optional CIDR prefix length, e.g. 0.0.0.0/0
-            destination:
-                description:
-                required: true
-                    Destination address with optional CIDR prefix length, e.g. 0.0.0.0/0
-            protocol:
-                description: IP protocol, such as 'tcp', 'udp' or 'any'.
-            port:
-                description: port number
-                required: false
-            action:
-                description: |
-                    action to take if the rule matches. Can be 'accept', 'drop' or 'reject'.
-            log:
-                description: whether to log matches of the rule.
-                type: bool
-                required: true
-            order:
-                description: position of the rule in the chain.
-                type: int
-                required: true
 
         outbound:
           description: |
-              list of rule dictionaries for outbound rules to be created in
-              GEO_OUT_ALLOW chain. These dictionaries will be processed by
-              cloudcix_primitives.utils.write_rule().
+              list of GeoIP address sets to allow as destinations for outbund
+              traffic. All sets listed must exist. Can be empty.
           type: list
           required: true
-          properties:
-            version:
-                type: int
-                description:
-                required: true
-                    IP version. Must be either 4 or 6.
-            source:
-                description:
-                type: string
-                required: true
-                    Source address with optional CIDR prefix length, e.g. 0.0.0.0/0
-            destination:
-                description:
-                required: true
-                    Destination address with optional CIDR prefix length, e.g. 0.0.0.0/0
-            protocol:
-                description: IP protocol, such as 'tcp', 'udp' or 'any'.
-            port:
-                description: port number
-                required: false
-            action:
-                description: |
-                    action to take if the rule matches. Can be 'accept', 'drop' or 'reject'.
-            log:
-                description: whether to log matches of the rule.
-                type: bool
-                required: true
-            order:
-                description: position of the rule in the chain.
-                type: int
-                required: true
     return:
         description: |
             A tuple with a boolean flag stating if the build was successful or not and
@@ -120,27 +56,27 @@ def build(
 
     3021: f'Failed to connect to the enabled PodNet for flush_inbound payload: ',
     3022: f'Failed to run flush_inbound payload on the enabled PodNet. Payload exited with status ',
-    3023: f'Failed to connect to the enabled PodNet for create_inbound_rule payload (%(payload)s): ',
-    3024: f'Failed to run create_inbound_rule payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3023: f'Failed to connect to the enabled PodNet for add_inbound_set payload (%(payload)s): ',
+    3024: f'Failed to run add_inbound_set payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
     3025: f'Failed to connect to the enabled PodNet for add_inbound_drop payload (%(payload)s): ',
     3036: f'Failed to run add_inbound_drop payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
     3067: f'Failed to connect to the enabled PodNet for flush_outbound payload: ',
     3028: f'Failed to run flush_outbound payload on the enabled PodNet. Payload exited with status ',
-    3029: f'Failed to connect to the enabled PodNet for create_outbound_rule payload (%(payload)s): ',
-    3030: f'Failed to run create_outbound_rule payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
+    3029: f'Failed to connect to the enabled PodNet for add_outbound_set payload (%(payload)s): ',
+    3030: f'Failed to run add_outbound_set payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
     3031: f'Failed to connect to the enabled PodNet for add_outbound_drop payload (%(payload)s): ',
     3032: f'Failed to run add_outbound_drop payload (%(payload)s) on the enabled PodNet. Payload exited with status ',
 
     3061: f'Failed to connect to the disabled PodNet for flush_inbound payload: ',
     3062: f'Failed to run flush_inbound payload on the disabled PodNet. Payload exited with status ',
-    3063: f'Failed to connect to the disabled PodNet for create_inbound_rule payload (%(payload)s): ',
-    3064: f'Failed to run create_inbound_rule payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    3063: f'Failed to connect to the disabled PodNet for add_inbound_set payload (%(payload)s): ',
+    3064: f'Failed to run add_inbound_set payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
     3065: f'Failed to connect to the disabled PodNet for add_inbound_drop payload (%(payload)s): ',
     3036: f'Failed to run add_inbound_drop payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
     3067: f'Failed to connect to the disabled PodNet for flush_outbound payload: ',
     3068: f'Failed to run flush_outbound payload on the disabled PodNet. Payload exited with status ',
-    3069: f'Failed to connect to the disabled PodNet for create_outbound_rule payload (%(payload)s): ',
-    3070: f'Failed to run create_outbound_rule payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
+    3069: f'Failed to connect to the disabled PodNet for add_outbound_set payload (%(payload)s): ',
+    3070: f'Failed to run add_outbound_set payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
     3071: f'Failed to connect to the disabled PodNet for add_outbound_drop payload (%(payload)s): ',
     3072: f'Failed to run add_outbound_drop payload (%(payload)s) on the disabled PodNet. Payload exited with status ',
     }
@@ -170,6 +106,11 @@ def build(
             {'payload_message': 'STDOUT', 'payload_error': 'STDERR'},
             successful_payloads
         )
+        
+        rule_templates = {
+            'add_inbound_set': f'ip netns exec {namespace} nft add rule inet FILTER GEO_IN_ALLOW ip%(ip_version)s saddr @%(set)s accept',
+            'add_outbound_set': f'ip netns exec {namespace} nft add rule inet FILTER GEO_OUT_ALLOW ip%(ip_version)s saddr @%(set)s accept',
+        }
 
         payloads = {
             'flush_inbound': f'ip netns exec {namespace} nft flush chain inet FILTER GEO_IN_ALLOW',
@@ -185,15 +126,20 @@ def build(
             return False, fmt.payload_error(ret, f"{prefix+2}: " + messages[prefix+2]), fmt.successful_payloads
         fmt.add_successful('flush_inbound', ret)
 
-        for rule in sorted(inbound, key=lambda fw: fw['order']):
-            payload = write_rule(namespace=namespace, rule=rule, user_chain='PROJECT_IN')
+        for address_set in inbound:
+            if address_set.endswith('_V4'):
+                ip_version = ''
+            if address_set.endswith('_V6'):
+                ip_version = '6'
+
+            payload = rule_templates['add_inbound_set'] % {'set': address_set, 'ip_version': ip_version}
 
             ret = rcc.run(payload)
             if ret["channel_code"] != CHANNEL_SUCCESS:
                 return False, fmt.channel_error(ret, f"{prefix+3}: " + messages[prefix+3] % {'payload': payload}), fmt.successful_payloads
             if ret["payload_code"] != SUCCESS_CODE:
                 return False, fmt.payload_error(ret, f"{prefix+4}: " + messages[prefix+4] % {'payload': payload}), fmt.successful_payloads
-            fmt.add_successful('create_inbound_rule (%s)' % payload, ret)
+            fmt.add_successful('add_inbound_set (%s)' % payload, ret)
 
         if (len(inbound) > 0):
             ret = rcc.run(payloads['add_inbound_drop'])
@@ -210,15 +156,20 @@ def build(
             return False, fmt.payload_error(ret, f"{prefix+8}: " + messages[prefix+8]), fmt.successful_payloads
         fmt.add_successful('flush_outbound', ret)
 
-        for rule in sorted(outbound, key=lambda fw: fw['order']):
-           payload = write_rule(namespace=namespace, rule=rule, user_chain='PROJECT_OUT')
+        for address_set in outbound:
+            if address_set.endswith('_V4'):
+                ip_version = ''
+            if address_set.endswith('_V6'):
+                ip_version = '6'
 
-           ret = rcc.run(payload)
-           if ret["channel_code"] != CHANNEL_SUCCESS:
-               return False, fmt.channel_error(ret, f"{prefix+9}: " + messages[prefix+9] % {'payload': payload}), fmt.successful_payloads
-           if ret["payload_code"] != SUCCESS_CODE:
-               return False, fmt.payload_error(ret, f"{prefix+10}: " + messages[prefix+10] % {'payload': payload}), fmt.successful_payloads
-           fmt.add_successful('create_outbound_rule (%s)' % payload, ret)
+            payload = rule_templates['add_outbound_set'] % {'set': address_set, 'ip_version': ip_version}
+
+            ret = rcc.run(payload)
+            if ret["channel_code"] != CHANNEL_SUCCESS:
+                return False, fmt.channel_error(ret, f"{prefix+9}: " + messages[prefix+9] % {'payload': payload}), fmt.successful_payloads
+            if ret["payload_code"] != SUCCESS_CODE:
+                return False, fmt.payload_error(ret, f"{prefix+10}: " + messages[prefix+10] % {'payload': payload}), fmt.successful_payloads
+            fmt.add_successful('add_outbound_set (%s)' % payload, ret)
 
         if (len(outbound) > 0):
             ret = rcc.run(payloads['add_outbound_drop'])

--- a/tools/test_geo_a_firewall_ns.py
+++ b/tools/test_geo_a_firewall_ns.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+from cloudcix_primitives import geo_a_firewall_ns
+
+# Prerequisites for running this test script:
+#
+#   tools/test_ns.py build ns1100
+#   tools/test_bridgeif_ns.py build br-B1 ns1100
+#   tools/test_default_firewall_ns.py build ns1100 br-B1
+#   tools/test_set_firewall_ns.py build ns1100 IE_V4 '8.8.8.8, 1.1.1.1, 192.168.0.1/24'
+#   tools/test_set_firewall_ns.py build ns1100 GB_V4 '9.9.9.9, 2.2.2.2, 192.168.0.1/24'
+
+# Fetch command and arguments
+cmd = sys.argv[1] if len(sys.argv) > 1 else None
+namespace_name = "ns1100"
+inbound=[
+    'IE_V4', 
+    'GB_V4',
+]
+
+outbound=[
+    'IE_V4', 
+    'GB_V4',
+]
+
+config_file = "/etc/cloudcix/pod/configs/config.json"
+
+if len(sys.argv) > 2:
+    namespace_name = sys.argv[2]
+if len(sys.argv) > 3:
+    inbound = json.loads(sys.argv[3])
+if len(sys.argv) > 3:
+    outbound = json.loads(sys.argv[4])
+
+
+status = None
+msg = None
+data = None
+
+# Check and execute command
+if cmd == 'build':
+    status, msg = geo_a_firewall_ns.build(namespace_name, inbound, outbound, config_file)
+elif cmd == 'read':
+    status, data, msg = geo_a_firewall_ns.read(namespace_name, config_file)
+elif cmd == 'scrub':
+    status, msg = geo_a_firewall_ns.scrub(namespace_name, config_file)
+else:
+   print(f"Unknown command: {cmd}")
+   sys.exit(1)
+
+
+# Output the status and messages
+print("Status: %s" % status)
+print("\nMessage:")
+if isinstance(msg, list):
+    for item in msg:
+        print(item)
+else:
+    print(msg)
+
+# Output data if available
+if data is not None:
+    print("\nData:")
+    print(json.dumps(data, sort_keys=True, indent=4))

--- a/tools/test_geo_a_firewall_ns.py
+++ b/tools/test_geo_a_firewall_ns.py
@@ -9,8 +9,9 @@ from cloudcix_primitives import geo_a_firewall_ns
 #   tools/test_ns.py build ns1100
 #   tools/test_bridgeif_ns.py build br-B1 ns1100
 #   tools/test_default_firewall_ns.py build ns1100 br-B1
-#   tools/test_set_firewall_ns.py build ns1100 IE_V4 '8.8.8.8, 1.1.1.1, 192.168.0.1/24'
-#   tools/test_set_firewall_ns.py build ns1100 GB_V4 '9.9.9.9, 2.2.2.2, 192.168.0.1/24'
+#   tools/test_set_firewall_ns.py build ns1100 IE_V4 ipv4_addr '8.8.8.8, 1.1.1.1, 192.168.0.1/24'
+#   tools/test_set_firewall_ns.py build ns1100 GB_V4 ipv4_addr '9.9.9.9, 2.2.2.2, 192.168.0.1/24'
+#   tools/test_set_firewall_ns.py build ns1100 IS_V6 ipv6_addr '2600:1406:3a00:21::173e:2e65, 2600:1406:3a00:21::173e:2e66, 5:6:7::/64'
 
 # Fetch command and arguments
 cmd = sys.argv[1] if len(sys.argv) > 1 else None
@@ -18,11 +19,13 @@ namespace_name = "ns1100"
 inbound=[
     'IE_V4', 
     'GB_V4',
+    'IS_V6',
 ]
 
 outbound=[
     'IE_V4', 
     'GB_V4',
+    'IS_V6',
 ]
 
 config_file = "/etc/cloudcix/pod/configs/config.json"

--- a/tools/test_geo_a_firewall_ns.py
+++ b/tools/test_geo_a_firewall_ns.py
@@ -9,9 +9,12 @@ from cloudcix_primitives import geo_a_firewall_ns
 #   tools/test_ns.py build ns1100
 #   tools/test_bridgeif_ns.py build br-B1 ns1100
 #   tools/test_default_firewall_ns.py build ns1100 br-B1
-#   tools/test_set_firewall_ns.py build ns1100 IE_V4 ipv4_addr '8.8.8.8, 1.1.1.1, 192.168.0.1/24'
-#   tools/test_set_firewall_ns.py build ns1100 GB_V4 ipv4_addr '9.9.9.9, 2.2.2.2, 192.168.0.1/24'
-#   tools/test_set_firewall_ns.py build ns1100 IS_V6 ipv6_addr '2600:1406:3a00:21::173e:2e65, 2600:1406:3a00:21::173e:2e66, 5:6:7::/64'
+#   tools/test_set_firewall_ns.py build ns1100 IE_V4 ipv4_addr
+#   tools/test_set_firewall_ns.py update ns1100 IE_V4 '8.8.8.8, 1.1.1.1, 192.168.0.1/24'
+#   tools/test_set_firewall_ns.py build ns1100 GB_V4 ipv4_addr
+#   tools/test_set_firewall_ns.py update ns1100 GB_V4 '9.9.9.9, 2.2.2.2, 192.168.0.1/24'
+#   tools/test_set_firewall_ns.py build ns1100 IS_V6 ipv6_addr
+#   tools/test_set_firewall_ns.py update ns1100 IS_V6 '2600:1406:3a00:21::173e:2e65, 2600:1406:3a00:21::173e:2e66, 5:6:7::/64'
 
 # Fetch command and arguments
 cmd = sys.argv[1] if len(sys.argv) > 1 else None


### PR DESCRIPTION
This pull request implements the `geo_a_firewall_ns` primitive. The test script requires the `set_firewall_ns` primitive, so I created a development branch that includes it in the state I tested against: https://github.com/jgrassler/primitives/tree/devel-geo_a_firewall_ns

Rule set diff from testing:

```
root@podnet-b:~# diff -u ruleset.set_firewall_ns-pre_geo_a_firewall_ns ruleset.geo_a_firewall_ns
--- ruleset.set_firewall_ns-pre_geo_a_firewall_ns       2025-01-31 15:24:55.294643470 +0000
+++ ruleset.geo_a_firewall_ns   2025-01-31 15:25:33.936053006 +0000
@@ -85,12 +85,20 @@
        }
 
        chain GEO_IN_ALLOW {
+               ip saddr @IE_V4 accept
+               ip saddr @GB_V4 accept
+               ip6 saddr @IS_V6 accept
+               drop
        }
 
        chain GEO_IN_BLOCK {
        }
 
        chain GEO_OUT_ALLOW {
+               ip saddr @IE_V4 accept
+               ip saddr @GB_V4 accept
+               ip6 saddr @IS_V6 accept
+               drop
        }
 
        chain GEO_OUT_BLOCK {
root@podnet-b:~#
```