### PR TITLE
Implement cpu_hyperv primitive (#84)

### DIFF
--- a/cloudcix_primitives/cpu_hyperv.py
+++ b/cloudcix_primitives/cpu_hyperv.py
@@ -1,13 +1,168 @@
+"""
+Primitive for modifying virtual machine's CPU count on Windows hypervisor
+"""
 # stdlib
-from typing import Tuple
+from typing import Any, Dict, List, Tuple
 # lib
+from cloudcix.rcc import CHANNEL_SUCCESS, comms_lsh, comms_ssh
 # local
-
+from cloudcix_primitives.utils import (
+    HostErrorFormatter,
+    SSHCommsWrapper,
+    hyperv_dictify,
+)
 
 __all__ = [
     'update',
+    'read',
 ]
 
+SUCCESS_CODE = 0
 
-def update() -> Tuple[bool, str]:
-    return(False, 'Not Implemented')
+
+def update(
+    host: str,
+    vm_identifier: str,
+    cpu: int,
+) -> Tuple[bool, str]:
+    """
+    description: modifies a HyperV virtual machine's number of CPUs
+
+    parameters:
+        host:
+            description: The DNS name or IP address of the host on which the domain is built
+            type: string
+            required: true
+        vm_identifier:
+            description: Unique identification name for the HyperV VM on the HyperV Host.
+            type: string
+            required: true
+        cpu:
+            description: Number of CPUs for the HyperV VM
+            type: integer
+            required: true
+    return:
+        description: |
+            A tuple with a boolean flag stating the build was successful or not and
+            the output or error message.
+        type: tuple
+    """
+
+    # Path Variables required by the payloads to build a VM.
+
+    # Define message
+    messages = {
+        1000: f'Successfully set CPU count for VM {vm_identifier} on Host {host} to {cpu}.',
+        # payload execution
+        3031: f'Failed to connect to the host {host} for get_state payload.',
+        3032: f'Failed to to run get_state payload on host {host}: ',
+        3033: f'Unexpected state for VM. Must be `Off` for changing number of CPUs but current state is: ',
+        3034: f'Failed to connect to the host {host} for set_cpu payload.',
+        3035: f'Failed to to run set_cpu payload on host {host}: ',
+    }
+
+    def run_host(host, prefix, successful_payloads):
+        rcc = SSHCommsWrapper(comms_ssh, host, 'administrator')
+        fmt = HostErrorFormatter(
+            host,
+            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'},
+            successful_payloads
+        )
+
+        payloads = {
+            'get_state':    f'$state = Get-VM -Name "{vm_identifier}"; $state.State',
+            'set_cpu':      f'Set-VMProcessor -VMName {vm_identifier} -Count {cpu}',
+        }
+
+        ret = rcc.run(payloads['get_state'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f'{prefix + 1}: {messages[prefix + 1]}'), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f'{prefix + 2}: {messages[prefix + 2]}'), fmt.successful_payloads
+        fmt.add_successful('get_state', ret)
+
+        if ret['payload_message'].strip() != "Off":
+            return False, f'{prefix + 3}: {messages[prefix + 3]} {ret["payload_message"]}', fmt.successful_payloads
+
+        ret = rcc.run(payloads['set_cpu'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            return False, fmt.channel_error(ret, f'{prefix + 4}: {messages[prefix + 4]}'), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            return False, fmt.payload_error(ret, f'{prefix + 5}: {messages[prefix + 5]}'), fmt.successful_payloads
+        fmt.add_successful('set_ram', ret)
+
+        return True, "", fmt.successful_payloads
+
+    status, msg, successful_payloads = run_host(host, 3030, {})
+    if status is False:
+        return status, msg
+
+    return True, f'1000: {messages[1000]}'
+
+
+def read(
+    host: str,
+    vm_identifier: str,
+) -> Tuple[bool, str]:
+    """
+    description: gets a HyperV virtual machine's number of CPUs
+
+    parameters:
+        host:
+            description: The DNS name or IP address of the host on which the domain is built
+            type: string
+            required: true
+        vm_identifier:
+            description: Unique identification name for the HyperV VM on the HyperV Host.
+            type: string
+            required: true
+    return:
+        description: |
+            A tuple with a boolean flag stating the build was successful or not and
+            the output or error message.
+        type: tuple
+    """
+
+    # Path Variables required by the payloads to build a VM.
+
+    # Define message
+    messages = {
+        1200: f'Successfully retrieved CPU count for VM {vm_identifier} on Host {host}.',
+        # payload execution
+        3031: f'Failed to connect to the host {host} for get_cpu payload.',
+        3032: f'Failed to to run get_cpu payload on host {host}: ',
+        3032: f'Failed to to run get_cpu payload on host {host}: ',
+    }
+
+    data_dict = {}
+    message_list = []
+
+    def run_host(host, prefix, successful_payloads):
+        rcc = SSHCommsWrapper(comms_ssh, host, 'administrator')
+        fmt = HostErrorFormatter(
+            host,
+            {'payload_message': 'STDOUT', 'payload_error': 'STDERR'},
+            successful_payloads
+        )
+
+        payloads = {
+            'get_cpu':      f'Get-VMProcessor {vm_identifier}',
+        }
+
+        ret = rcc.run(payloads['get_cpu'])
+        if ret["channel_code"] != CHANNEL_SUCCESS:
+            fmt.store_channel_error(ret, f'{prefix + 1}: {messages[prefix + 1]}'), fmt.successful_payloads
+        if ret["payload_code"] != SUCCESS_CODE:
+            fmt.store_payload_error(ret, f'{prefix + 2}: {messages[prefix + 2]}'), fmt.successful_payloads
+        else:
+            fmt.add_successful('get_cpu', ret)
+            # CPU count will be under key `Count`
+            data_dict[host] = hyperv_dictify(ret["payload_message"])
+
+        return True, fmt.message_list, fmt.successful_payloads, data_dict
+
+    status, msg_list, successful_payloads, data_dict = run_host(host, 3030, {})
+    if status is False:
+        return status, data_dict, message_list
+    else:
+        return status, data_dict, [f'1200: {messages[1200]}']

--- a/tools/test_cpu_hyperv.py
+++ b/tools/test_cpu_hyperv.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+from cloudcix_primitives import cpu_hyperv
+
+# Run the following test scripts before this one:
+# * `tools/test_ns.py build mynetns` to ensure the name space exists
+# * `tools/test_vlanif_ns.py build {vlan} to ensure vlan tagged interface exists on podnet
+# * `tools/test_network_ns.py build mynetns` to ensure the name space exists
+# * `tools/test_hyperv.py build 2a02:2078:9::20:0:1 robot.devtest-cork-01.cloudcix.net 1234_5678` to ensure there is a VM to operate on
+# * `tools/test_hyperv.py quiesce 2a02:2078:9::20:0:1 None 1234_5678` to ensure the VM is in the correct state for modifying CPU count.
+
+cmd = sys.argv[1]
+
+host = None
+ram = 4
+
+if len(sys.argv) > 2:
+    host = sys.argv[2]
+
+if len(sys.argv) > 3:
+    vm_identifier = sys.argv[3]
+
+if len(sys.argv) > 4:
+    cpu = sys.argv[4]
+
+if host is None:
+    print('Host is required, please supply the host as second argument.')
+    exit()
+
+if vm_identifier is None:
+    print('vm_identifier is required, please the vm_identifier as third argument.')
+    exit()
+
+status = None
+msg = None
+data = None
+
+if cmd == 'update':
+    status, msg = cpu_hyperv.update(
+        host=host,
+        vm_identifier=vm_identifier,
+        cpu=cpu,
+    )
+elif cmd == 'read':
+    status, data, msg = cpu_hyperv.read(host=host, vm_identifier=vm_identifier)
+else:
+   print(f"Unknown command: {cmd}")
+   sys.exit(1)
+
+
+print("Status: %s" %  status)
+print()
+print("Message:")
+if type(msg) == list:
+    for item in msg:
+        print(item)
+else:
+    print(msg)
+
+if data is not None:
+    print()
+    print("Data:")
+    print(json.dumps(data, sort_keys=True, indent=4))


### PR DESCRIPTION
This commits implements the cpu_hyperv primitive. In addition to the `update` verb specified in the issue it also implements a `read` verb because that data is missing from the output of the `Get-VM -Name <VM identifier>` command run by `hyperv.read()`.