### PR TITLE
hyperv: fix braces in quiesce()

### DIFF
--- a/cloudcix_primitives/hyperv.py
+++ b/cloudcix_primitives/hyperv.py
@@ -440,7 +440,7 @@ def quiesce(host: str, vm_identifier: str) -> Tuple[bool, str]:
         payloads = {
             'shutdown_vm':  f'try {{ Stop-VM -Name {vm_identifier} }} catch {{}}; $timeout=300; $interval=1; $elapsed=0; '
                             f'while($elapsed -lt $timeout -and (Get-VM -Name {vm_identifier}).State -ne "Off")'
-                            '{{ Start-Sleep -Seconds $interval; $elapsed+=$interval; }}; '
+                            '{ Start-Sleep -Seconds $interval; $elapsed+=$interval; }; '
                             f'if((Get-VM -Name {vm_identifier}).State -ne "Off"){{ Stop-VM -Name $vmName -TurnOff }}',
             'get_state':    f'$state = Get-VM -Name "{vm_identifier}"; $state.State',
         }


### PR DESCRIPTION
We had overzealous escaping of curly braces in a string that wasn't an f-string. That lead to the shutdown_vm payload incorrectly having double curly braces around VM state check loop's body. With these double curly braces it never terminates if the payload is run with an invalid VM name.