### PR TITLE
Overhaul snapshot_hyperv primitive (#90)

### DIFF
--- a/cloudcix_primitives/snapshot_hyperv.py
+++ b/cloudcix_primitives/snapshot_hyperv.py
@@ -149,7 +149,7 @@ def read(
         description: |
             A list with 3 items: (1) a boolean status flag indicating if the
             read was successful, (2) a dict containing the data as read from
-            the both machine's current state and (3) the list of debug and or error messages.
+            the machine's current state and (3) the list of debug and or error messages.
         type: tuple
         items:
           read:
@@ -414,12 +414,32 @@ def list(
             description: The dns or ipadddress of the Host on which the domain is built
             type: string
             required: true
-
     return:
         description: |
-            A tuple with a boolean flag stating the restore was successful or not and
-            the output or error message.
+            A list with 3 items: (1) a boolean status flag indicating if the
+            read was successful, (2) a dict containing the data as read from
+            the machine's current state and (3) the list of debug and or error messages.
         type: tuple
+        items:
+          read:
+            description: True if all read operations were successful, False otherwise.
+            type: boolean
+          data:
+            type: object
+            description: |
+              file contents retrieved from Host. May be None if nothing
+              could be retrieved.
+            properties:
+              <host>:
+                description: read output data from machine <host>
+                  type: string
+          messages:
+            description: list of errors and debug messages collected before failure occurred
+            type: array
+            items:
+              <message>:
+                description: exact message of the step, either debug, info or error type
+                type: string
     """
 
     # Define message

--- a/cloudcix_primitives/snapshot_hyperv.py
+++ b/cloudcix_primitives/snapshot_hyperv.py
@@ -480,4 +480,3 @@ def list(
         return retval, data_dict, message_list
     else:
         return True, data_dict, [f'1400: {messages[1400]}']
-    return status, data_dict, msg

--- a/cloudcix_primitives/utils.py
+++ b/cloudcix_primitives/utils.py
@@ -1,4 +1,5 @@
 # stdlib
+import csv
 import ipaddress
 import json
 import os
@@ -57,6 +58,16 @@ def hyperv_dictify(data):
     # Converting the paired data into a dictionary
     data_dict = dict(zip(items_line1, items_line3))
     return data_dict
+
+
+# useful for processing multi line output from tabular output piped into `ConvertTo-Csv -NoTypeInformation`
+def hyperv_dictify_csv(data):
+    rows = []
+    lines = data.strip().split('\r\n')
+    r = csv.DictReader(lines)
+    for row in r:
+        rows.append(dict(row))
+    return rows
 
 
 def load_pod_config(config_file=None, prefix=4000) -> Tuple[bool, Dict[str, Optional[Any]], str]:

--- a/tools/test_snapshot_hyperv.py
+++ b/tools/test_snapshot_hyperv.py
@@ -6,30 +6,29 @@ import sys
 from cloudcix_primitives import snapshot_hyperv
 
 # Run the following test scripts before this one:
-#
-# *  `tools/test_directory_hyperv.py build "D:\\HyperV\\myvm"`
-#
-# *  `tools/test_hyperv.py build "<host_ip>" "D:\\HyperV\\primitive_test" `
-#
+# * `tools/test_ns.py build mynetns` to ensure the name space exists
+# * `tools/test_vlanif_ns.py build {vlan} to ensure vlan tagged interface exists on podnet
+# * `tools/test_network_ns.py build mynetns` to ensure the name space exists
+# * `tools/test_hyperv.py build <host> <region_url> build 1234_5678 
 
 cmd = sys.argv[1]
 
 host = None
-domain = 'primitive_test'
-snapshot = 'snapshot_123'
+vm_identifier = '1234_5678'
+snapshot_identifier = 'snapshot_123'
 remove_subtree = False
 
 if len(sys.argv) > 2:
     host = sys.argv[2]
 
 if len(sys.argv) > 3:
-    domain = sys.argv[3]
+    vm_identifier = sys.argv[3]
 
 if len(sys.argv) > 4:
-    snapshot = sys.argv[4]
+    snapshot_identifier = sys.argv[4]
 
 if len(sys.argv) > 5:
-    remove_subtree = sys.argv[5]
+    remove_subtree = bool(sys.argv[5])
 
 if host is None:
     print('Host is required, please supply the host as second argument.')
@@ -40,13 +39,15 @@ msg = None
 data = None
 
 if cmd == 'build':
-    status, msg = snapshot_hyperv.build(host=host, domain=domain, snapshot=snapshot)
+    status, msg = snapshot_hyperv.build(host=host, vm_identifier=vm_identifier, snapshot_identifier=snapshot_identifier)
 elif cmd == 'read':
-    status, data, msg = snapshot_hyperv.read(host=host, domain=domain, snapshot=snapshot)
+    status, data, msg = snapshot_hyperv.read(host=host, vm_identifier=vm_identifier, snapshot_identifier=snapshot_identifier)
+elif cmd == 'list':
+    status, data, msg = snapshot_hyperv.list(host=host, vm_identifier=vm_identifier)
 elif cmd == 'scrub':
-    status, msg = snapshot_hyperv.scrub(host=host, domain=domain, snapshot=snapshot, remove_subtree=remove_subtree)
+    status, msg = snapshot_hyperv.scrub(host=host, vm_identifier=vm_identifier, snapshot_identifier=snapshot_identifier, remove_subtree=remove_subtree)
 elif cmd == 'update':
-    status, msg = snapshot_hyperv.update(host=host, domain=domain, snapshot=snapshot)
+    status, msg = snapshot_hyperv.update(host=host, vm_identifier=vm_identifier, snapshot_identifier=snapshot_identifier)
 else:
    print(f"Unknown command: {cmd}")
    sys.exit(1)


### PR DESCRIPTION
This pull request modifies the snapshot_hyperv primitive to meet the POC based specification in #90.

Notable addition beyond the primitive: `hyperv_dictify_csv`. In combination with powershell's `ConvertTo-Csv` command, this can be very useful for any primitives where we need to exfiltrate tabular data.