### PR TITLE
Fix use of namespace and bridge to default_firewall_ns

### DIFF
--- a/cloudcix_primitives/default_firewall_ns.py
+++ b/cloudcix_primitives/default_firewall_ns.py
@@ -177,7 +177,7 @@ def build(
             f'ip netns exec {namespace} nft add rule inet FILTER PREROUTING '
             f'iifname {namespace}.{public_bridge} jump GEO_IN_ALLOW',
 
-            f'ip netns exec ns1100 nft add rule inet FILTER PREROUTING '
+            f'ip netns exec {namespace} nft add rule inet FILTER PREROUTING '
             f'iifname {namespace}.{public_bridge} jump GEO_IN_BLOCK',
 
 
@@ -192,28 +192,28 @@ def build(
             f'oifname {namespace}.{public_bridge} jump GEO_OUT_BLOCK',
 
             # FORWARD
-            f'ip netns exec ns1100 nft add rule inet FILTER FORWARD '
+            f'ip netns exec {namespace} nft add rule inet FILTER FORWARD '
             'ct state established,related accept',
 
-            f'ip netns exec ns1100 nft add rule inet FILTER FORWARD '
-            'iifname @PRIVATE oifname ns1100.br-B1 jump PROJECT_OUT',
+            f'ip netns exec {namespace} nft add rule inet FILTER FORWARD '
+            f'iifname @PRIVATE oifname {namespace}.{public_bridge} jump PROJECT_OUT',
 
-            f'ip netns exec ns1100 nft add rule inet FILTER FORWARD '
-            'iifname ns1100.br-B1 oifname @PRIVATE jump PROJECT_IN',
+            f'ip netns exec {namespace} nft add rule inet FILTER FORWARD '
+            f'iifname {namespace}.{public_bridge} oifname @PRIVATE jump PROJECT_IN',
 
-            f'ip netns exec ns1100 nft add rule inet FILTER FORWARD '
+            f'ip netns exec {namespace} nft add rule inet FILTER FORWARD '
             'iifname @PRIVATE oifname @S2S_TUNNEL jump VPNS2S',
 
-            f'ip netns exec ns1100 nft add rule inet FILTER FORWARD '
+            f'ip netns exec {namespace} nft add rule inet FILTER FORWARD '
             'iifname @S2S_TUNNEL oifname @PRIVATE jump VPNS2S',
 
-            f'ip netns exec ns1100 nft add rule inet FILTER FORWARD '
+            f'ip netns exec {namespace} nft add rule inet FILTER FORWARD '
             'iifname @PRIVATE oifname @DYN_TUNNEL jump VPNDYN',
 
-            f'ip netns exec ns1100 nft add rule inet FILTER FORWARD '
+            f'ip netns exec {namespace} nft add rule inet FILTER FORWARD '
             'iifname @DYN_TUNNEL oifname @PRIVATE jump VPNDYN',
 
-            f'ip netns exec ns1100 nft add rule inet FILTER FORWARD '
+            f'ip netns exec {namespace} nft add rule inet FILTER FORWARD '
             'iifname @PRIVATE oifname @PRIVATE jump PRVT_2_PRVT',
 
         ]


### PR DESCRIPTION
Came up in testing wondering why `tools/test_default_firewall_ns.py build noahns noahbr` was complaining about `ns1100` not existing 
```
3046: Failed to run create_rule payload (ip netns exec ns1100 nft add rule inet FILTER PREROUTING iifname noahns.noahbr jump GEO_IN_BLOCK) on the enabled PodNet. Payload exited with status payload code: 255
STDERR: Cannot open network namespace "ns1100": No such file or directory
```