### PR TITLE
update net_main + jinja template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ log.*
 
 # Ruby stuff
 Gemfile.lock
+tools/test_net_main.py

--- a/cloudcix_primitives/net_main.py
+++ b/cloudcix_primitives/net_main.py
@@ -24,12 +24,13 @@ def build(
         host: str,
         filename: str,
         standard_name: str,
-        system_name: str,
+        system_name: str = '',
         config_filepath=None,
         ips=None,
         mac=None,
         routes=None,
         vlans=None,
+        bonds=None,
 ) -> Tuple[bool, str]:
     """
     description:
@@ -94,7 +95,46 @@ def build(
                             type: string
                         via:
                             description: IP addresses from which the traffic is directed
-
+        bonds:
+            description: List of bond interface objects defined on vlan interface
+            type: list
+            properties:
+                name:
+                    description: The name of the bond interface to which this vlan belongs.
+                    type: string
+                dhcp4:
+                    description: Boolean value to indicate if the bond interface should use DHCP for IPv4
+                    type: boolean
+                dhcp6:
+                    description: Boolean value to indicate if the bond interface should use DHCP for IPv6
+                    type: boolean
+                interfaces:
+                    description: List of interfaces that are part of the bond
+                    type: list
+                    items:
+                        type: string
+                parameters:
+                    description: Dictionary of parameters for the bond interface
+                    type: dict
+                    properties:
+                        mode:
+                            description: The bonding mode to be used for the bond interface
+                            type: string
+                        primary:
+                            description: The primary interface for the bond interface
+                            type: string    
+                addresses:
+                    description: List of IP addresses defined on bond interface, in string format
+                    type: list
+                routes:
+                    description: List of route objects defined on bond interface
+                    type: list
+                    properties:
+                        to:
+                            description: IP addresses to which the traffic is destined
+                            type: string
+                        via:
+                            description: IP addresses from which the traffic is directed
     return:
         description: |
             A tuple with a boolean flag stating whether the build was successful or not and
@@ -131,6 +171,7 @@ def build(
         'standard_name': standard_name,
         'system_name': system_name,
         'vlans': vlans,
+        'bonds': bonds,
     }
 
     # ensure all the required keys are collected and no key has None value for template_data
@@ -144,10 +185,10 @@ def build(
 
     # Prepare public bridge build config
     bash_script = template.render(**template_data)
-    logger.debug(
+    logger.info(
         f'Generated build bash script for Netplan Interface #{standard_name}\n{bash_script}',
     )
-
+    print(bash_script)
     success, output = False, ''
     # Deploy the bash script to the Host
     if host in ['127.0.0.1', None, '', 'localhost']:

--- a/cloudcix_primitives/templates/net_main/configs/netplan.yaml.j2
+++ b/cloudcix_primitives/templates/net_main/configs/netplan.yaml.j2
@@ -2,6 +2,15 @@ network:
   version: 2
   renderer: networkd
   ethernets:
+{% if bonds is not none and bonds | length > 0 %}
+{% for bond in bonds %}
+{% for interface in bond['interfaces'] %}
+    {{ interface }}:
+      dhcp4: false
+      dhcp6: false
+{% endfor %}
+{% endfor %}
+{% else %}
     {{ system_name }}:
       dhcp4: false
       dhcp6: false
@@ -22,6 +31,35 @@ network:
 {% for route in routes %}
         - to: {{ route['to'] }}
           via: {{ route['via'] }}
+{% endfor %}
+{% endif %}
+{% endif %}
+
+{% if bonds is not none and bonds | length > 0 %}
+  bonds:
+{% for bond in bonds %}
+    {{ bond['name'] }}:
+      dhcp4: false
+      dhcp6: false
+      interfaces: [{% for iface in bond['interfaces'] %}{{ iface }}{% if not loop.last %}, {% endif %}{% endfor %}]
+      parameters:
+        mode: {{ bond['parameters']['mode'] }}
+{% if bond['parameters']['primary']%}
+        primary: {{ bond['parameters']['primary'] }}
+{% endif %}
+{% if bond['addresses'] is not none and bond['addresses'] | length > 0 %}
+      addresses:
+{% for address in bond['addresses'] %}
+        - {{ address }}
+{% endfor %}
+{% endif %}
+{% if bond['routes'] is not none and bond['routes'] | length > 0 %}
+      routes:
+{% for route in bond['routes'] %}
+        - to: {{ route['to'] }}
+          via: {{ route['via'] }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Co-authored-by: TVKain <tvkain.it@gmail.com>

This enabled support for bonded network interfaces in `pod_installer`

Example usage:

```python
from cloudcix_primitives import net_main
test_bonds = [
    {
        'name': 'mgmt0',
        'dhcp4': False,
        'dhcp6': False,
        'interfaces': ['eno1', 'eno2'],
        'parameters': {
            'mode': '802.3ad',
        },
        'addresses': [
            '10.0.0.10/24',
            '2001:db8::10/64',
        ],
    },
]
configured, error=net_main.build(
    host='localhost',
    filename='011-mgmt0.yaml',
    standard_name='mgmt0',
    bonds=test_bonds,
)
print(f'Configured: {configured}, Error: {error}')
```

